### PR TITLE
pass configurationStore by reference

### DIFF
--- a/eppoclient/configurationrequestor.go
+++ b/eppoclient/configurationrequestor.go
@@ -14,10 +14,10 @@ type iConfigRequestor interface {
 
 type experimentConfigurationRequestor struct {
 	httpClient  httpClient
-	configStore configurationStore
+	configStore *configurationStore
 }
 
-func newExperimentConfigurationRequestor(httpClient httpClient, configStore configurationStore) *experimentConfigurationRequestor {
+func newExperimentConfigurationRequestor(httpClient httpClient, configStore *configurationStore) *experimentConfigurationRequestor {
 	return &experimentConfigurationRequestor{
 		httpClient:  httpClient,
 		configStore: configStore,

--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -9,7 +9,7 @@ import (
 )
 
 type configurationStore struct {
-	cache lru.Cache
+	cache *lru.Cache
 }
 
 type Variation struct {
@@ -31,7 +31,7 @@ func newConfigurationStore(maxEntries int) *configurationStore {
 	var configStore = &configurationStore{}
 
 	lruCache, err := lru.New(maxEntries)
-	configStore.cache = *lruCache
+	configStore.cache = lruCache
 
 	if err != nil {
 		panic(err)

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -14,7 +14,7 @@ func InitClient(config Config) *EppoClient {
 
 	httpClient := newHttpClient(config.BaseUrl, &http.Client{Timeout: REQUEST_TIMEOUT_SECONDS}, sdkParams)
 	configStore := newConfigurationStore(MAX_CACHE_ENTRIES)
-	requestor := newExperimentConfigurationRequestor(*httpClient, *configStore)
+	requestor := newExperimentConfigurationRequestor(*httpClient, configStore)
 	assignmentLogger := NewAssignmentLogger()
 
 	client := newEppoClient(requestor, assignmentLogger)


### PR DESCRIPTION
Got a linter warning:

```
[lint: eppoclient/configurationrequestor.go#L20](https://github.com/Eppo-exp/golang-sdk/commit/a3e57949f19747a09dfe730c3b7ebaff8131306f#annotation_4440670782)
copylocks: newExperimentConfigurationRequestor passes lock by value: github.com/Eppo-exp/golang-sdk/eppoclient.configurationStore contains github.com/hashicorp/golang-lru.Cache contains sync.RWMutex (govet)
```

IMO most of the lint warnings are spurious but this one seems useful.