### PR TITLE
Feature/assignment logger interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,4 @@ This version of the SDK is compatible with Go v1.18 and above.
 			// do something
 		}
 	}
-<<<<<<< HEAD
 ```
-=======
-```
->>>>>>> 1732d6bdadffc0e80011a86c49a50d56546c6296

--- a/README.md
+++ b/README.md
@@ -1,13 +1,38 @@
 # Eppo SDK for Golang
 
-## Building
+Eppoclient is a client sdk for `eppo.cloud` randomization API.
+It is used to retrieve the experiments data and put it to in-memory cache, and then get assignments information.
+
+## Getting Started
+
+Refer to our [SDK documentation](https://docs.geteppo.com/feature-flagging/randomization-sdk/) for how to install and use the SDK.
+
+## Supported Python Versions
+This version of the SDK is compatible with Python 3.6 and above.
+
+## Example
+
 
 ```
-make build
-```
+	import (
+		"github.com/Eppo-exp/golang-sdk/eppoclient"
+	)
 
-## Running tests
+	var eppoClient = &eppoclient.EppoClient{}
 
-```
-make test
+	func main() {
+		eppoClient = eppoclient.InitClient(eppoclient.Config{
+			ApiKey:           "<your_api_key>",
+			BaseUrl:          "<base_url>", // optional, default https://eppo.cloud/api
+			AssignmentLogger: eppoclient.AssignmentLogger{},
+		})
+	}
+
+	func someBLFunc() {
+		assignment, _ := eppoClient.GetAssignment("subject-1", "experiment_5", sbjAttrs)
+
+		if assigment == "control" {
+			// do something
+		}
+	}
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is used to retrieve the experiments data and put it to in-memory cache, and t
 
 Refer to our [SDK documentation](https://docs.geteppo.com/prerequisites/feature-flagging/randomization-sdk/) for how to install and use the SDK.
 
-## Supported Python Versions
+## Supported Go Versions
 This version of the SDK is compatible with Go v1.18 and above.
 
 ## Example

--- a/eppoclient/assignmentlogger.go
+++ b/eppoclient/assignmentlogger.go
@@ -3,7 +3,15 @@ package eppoclient
 import "fmt"
 
 type IAssignmentLogger interface {
-	LogAssignment(event map[string]string)
+	LogAssignment(event AssignmentEvent)
+}
+
+type AssignmentEvent struct {
+	Experiment        string
+	Variation         string
+	Subject           string
+	Timestamp         string
+	SubjectAttributes dictionary
 }
 
 type AssignmentLogger struct {
@@ -13,7 +21,7 @@ func NewAssignmentLogger() IAssignmentLogger {
 	return &AssignmentLogger{}
 }
 
-func (al *AssignmentLogger) LogAssignment(event map[string]string) {
+func (al *AssignmentLogger) LogAssignment(event AssignmentEvent) {
 	fmt.Println("Assignment Logged")
 	fmt.Println(event)
 }

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -75,7 +75,11 @@ func (ec *EppoClient) GetAssignment(subjectKey string, experimentKey string, sub
 		SubjectAttributes: subjectAttributes,
 	}
 
-	json.Marshal(assignmentEvent)
+	_, jsonErr := json.Marshal(assignmentEvent)
+
+	if jsonErr != nil {
+		panic("incorrect json")
+	}
 
 	func() {
 		// need to catch panics from Logger and continue

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -17,14 +17,6 @@ type EppoClient struct {
 	logger          IAssignmentLogger
 }
 
-type assignmentEvent struct {
-	Experiment        string
-	Variation         string
-	Subject           string
-	Timestamp         string
-	SubjectAttributes dictionary
-}
-
 func newEppoClient(configRequestor iConfigRequestor, assignmentLogger IAssignmentLogger) *EppoClient {
 	var ec = &EppoClient{}
 
@@ -75,7 +67,7 @@ func (ec *EppoClient) GetAssignment(subjectKey string, experimentKey string, sub
 
 	assignedVariation := variationShard.Name
 
-	assignmentEvent := &assignmentEvent{
+	assignmentEvent := AssignmentEvent{
 		Experiment:        experimentKey,
 		Variation:         assignedVariation,
 		Subject:           subjectKey,
@@ -83,7 +75,7 @@ func (ec *EppoClient) GetAssignment(subjectKey string, experimentKey string, sub
 		SubjectAttributes: subjectAttributes,
 	}
 
-	aeJson, _ := json.Marshal(assignmentEvent)
+	json.Marshal(assignmentEvent)
 
 	func() {
 		// need to catch panics from Logger and continue
@@ -94,10 +86,7 @@ func (ec *EppoClient) GetAssignment(subjectKey string, experimentKey string, sub
 			}
 		}()
 
-		event := map[string]string{}
-		json.Unmarshal([]byte(aeJson), &event)
-
-		ec.logger.LogAssignment(event)
+		ec.logger.LogAssignment(assignmentEvent)
 	}()
 
 	return assignedVariation, nil

--- a/eppoclient/mocks.go
+++ b/eppoclient/mocks.go
@@ -8,7 +8,7 @@ type mockLogger struct {
 	mock.Mock
 }
 
-func (ml *mockLogger) LogAssignment(event map[string]string) {
+func (ml *mockLogger) LogAssignment(event AssignmentEvent) {
 	ml.Called(event)
 }
 


### PR DESCRIPTION
I don't remember exactly why I decided to make 
```
type IAssignmentLogger interface {
	LogAssignment(event map[string]string)
}
```
maybe to keep up with js version, but now that I dove deep into GO it feels wrong.