### PR TITLE
Fix deserialization of targeting rules

### DIFF
--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -11,9 +11,9 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-
       - name: Build
         run: go build -v ./...
-
+      - name: 'Set up GCP SDK for downloading test data'
+        uses: 'google-github-actions/setup-gcloud@v0'
       - name: Test
         run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ eppo-golang-sdk-*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-eppoclient/test-data/assignment/*
+eppoclient/test-data/assignment-v2
+eppoclient/test-data/rac-experiments.json
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,15 @@ help: Makefile
 	@echo "usage: make <target>"
 	@sed -n 's/^##//p' $<
 
-test:
+testDataDir := eppoclient/test-data/
+.PHONY: test-data
+test-data:
+	rm -rf $(testDataDir)
+	mkdir -p $(testDataDir)
+	gsutil cp gs://sdk-test-data/rac-experiments.json $(testDataDir)
+	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
+
+test: test-data
 	go test ./...
 
 lint:

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -112,8 +112,8 @@ func Test_AssignSubjectWithAttributesAndRules(t *testing.T) {
 	var mockLogger = new(mockLogger)
 	mockLogger.Mock.On("LogAssignment", mock.Anything).Return()
 
-	var matchesEmailCondition = condition{operator: "MATCHES", value: ".*@eppo.com", attribute: "email"}
-	var textRule = rule{conditions: []condition{matchesEmailCondition}}
+	var matchesEmailCondition = condition{Operator: "MATCHES", Value: ".*@eppo.com", Attribute: "email"}
+	var textRule = rule{Conditions: []condition{matchesEmailCondition}}
 	var mockConfigRequestor = new(mockConfigRequestor)
 	var overrides = make(dictionary)
 	var mockVariations = []Variation{

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -1,12 +1,9 @@
 package eppoclient
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,14 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/api/iterator"
-	"google.golang.org/api/option"
 )
 
-const TEST_DATA_DIR = "test-data/assignment"
-const BUCKET_NAME = "sdk-test-data"
+const TEST_DATA_DIR = "test-data/assignment-v2"
+const MOCK_RAC_RESPONSE_FILE = "test-data/rac-experiments.json"
 
 var tstData = []testData{}
 
@@ -38,6 +32,16 @@ func Test_e2e(t *testing.T) {
 
 		assignments := []string{}
 
+		for _, subject := range experiment.SubjectsWithAttributes {
+			assignment, err := client.GetAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
+
+			if assignment != "" {
+				assert.Nil(t, err)
+			}
+
+			assignments = append(assignments, assignment)
+		}
+
 		for _, subject := range experiment.Subjects {
 			assignment, err := client.GetAssignment(subject, expName, dictionary{})
 
@@ -53,7 +57,6 @@ func Test_e2e(t *testing.T) {
 }
 
 func initFixture() string {
-	downloadTestData()
 	testResponse := getTestData() // this is here because we need to append to global testData
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -90,67 +93,9 @@ func getTestData() dictionary {
 		tstData = append(tstData, testCaseDict)
 	}
 
-	expConfigs := dictionary{}
-
-	for _, experimentTest := range tstData {
-		experimentName := experimentTest.Experiment
-		expMap := dictionary{}
-		expMap["subjectShards"] = 10000
-		expMap["enabled"] = true
-		expMap["variations"] = experimentTest.Variations
-		expMap["name"] = experimentName
-		expMap["percentExposure"] = experimentTest.PercentExposure
-
-		expConfigs[experimentName] = expMap
-	}
-
-	response := dictionary{}
-	response["experiments"] = expConfigs
-
-	return response
-}
-
-func downloadTestData() {
-	if _, err := os.Stat(TEST_DATA_DIR); os.IsNotExist(err) {
-		if err := os.MkdirAll(TEST_DATA_DIR, os.ModePerm); err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		return //data is already downloaded, skip this step
-	}
-
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
-	if err != nil {
-		fmt.Println(err)
-	}
-
-	query := &storage.Query{Prefix: "assignment/test-case"}
-	bkt := client.Bucket(BUCKET_NAME)
-	it := bkt.Objects(ctx, query)
-
-	for {
-		attrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			log.Fatal(err)
-		}
-		obj := bkt.Object(attrs.Name)
-		rdr, err := obj.NewReader(ctx)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer rdr.Close()
-
-		out, err := os.Create("test-data/" + obj.ObjectName())
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer out.Close()
-
-		io.Copy(out, rdr)
-	}
+	var racResponseData map[string]interface{}
+	racResponseJsonFile, _ := os.Open(MOCK_RAC_RESPONSE_FILE)
+	byteValue, _ := ioutil.ReadAll(racResponseJsonFile)
+	json.Unmarshal(byteValue, &racResponseData)
+	return racResponseData
 }

--- a/eppoclient/rules_test.go
+++ b/eppoclient/rules_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var greaterThanCondition = condition{operator: "GT", value: 10.0, attribute: "age"}
-var lessThanCondition = condition{operator: "LT", value: 100.0, attribute: "age"}
-var numericRule = rule{conditions: []condition{greaterThanCondition, lessThanCondition}}
+var greaterThanCondition = condition{Operator: "GT", Value: 10.0, Attribute: "age"}
+var lessThanCondition = condition{Operator: "LT", Value: 100.0, Attribute: "age"}
+var numericRule = rule{Conditions: []condition{greaterThanCondition, lessThanCondition}}
 
-var matchesEmailCondition = condition{operator: "MATCHES", value: ".*@email.com", attribute: "email"}
-var textRule = rule{conditions: []condition{matchesEmailCondition}}
-var ruleWithEmptyConditions = rule{conditions: []condition{}}
+var matchesEmailCondition = condition{Operator: "MATCHES", Value: ".*@email.com", Attribute: "email"}
+var textRule = rule{Conditions: []condition{matchesEmailCondition}}
+var ruleWithEmptyConditions = rule{Conditions: []condition{}}
 
 func Test_matchesAnyRule_withEmptyRules(t *testing.T) {
 	expected := false
@@ -84,8 +84,8 @@ func Test_matchesAnyRule_NumericOperatorWithString(t *testing.T) {
 func Test_matchesAnyRule_NumericValueAndRegex(t *testing.T) {
 	expected := true
 
-	cdn := condition{operator: "MATCHES", value: "[0-9]+", attribute: "age"}
-	rl := rule{conditions: []condition{cdn}}
+	cdn := condition{Operator: "MATCHES", Value: "[0-9]+", Attribute: "age"}
+	rl := rule{Conditions: []condition{cdn}}
 
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 99
@@ -102,8 +102,8 @@ type MatchesAnyRuleTest []struct {
 }
 
 func Test_matchesAnyRule_oneOfOperatorWithBoolean(t *testing.T) {
-	oneOfRule := rule{conditions: []condition{{operator: "ONE_OF", value: []string{"true"}, attribute: "enabled"}}}
-	notOneOfRule := rule{conditions: []condition{{operator: "NOT_ONE_OF", value: []string{"True"}, attribute: "enabled"}}}
+	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"true"}, Attribute: "enabled"}}}
+	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"True"}, Attribute: "enabled"}}}
 
 	subjectAttributesEnabled := make(dictionary)
 	subjectAttributesEnabled["enabled"] = "true"
@@ -126,7 +126,7 @@ func Test_matchesAnyRule_oneOfOperatorWithBoolean(t *testing.T) {
 }
 
 func Test_matchesAnyRule_OneOfOperatorCaseInsensitive(t *testing.T) {
-	oneOfRule := rule{conditions: []condition{{operator: "ONE_OF", value: []string{"1Ab", "Ron"}, attribute: "name"}}}
+	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"1Ab", "Ron"}, Attribute: "name"}}}
 	subjectAttributes0 := make(dictionary)
 	subjectAttributes0["name"] = "ron"
 
@@ -146,7 +146,7 @@ func Test_matchesAnyRule_OneOfOperatorCaseInsensitive(t *testing.T) {
 }
 
 func Test_matchesAnyRule_NotOneOfOperatorCaseInsensitive(t *testing.T) {
-	notOneOfRule := rule{conditions: []condition{{operator: "NOT_ONE_OF", value: []string{"bbB", "1.1.ab"}, attribute: "name"}}}
+	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"bbB", "1.1.ab"}, Attribute: "name"}}}
 	subjectAttributes0 := make(dictionary)
 	subjectAttributes0["name"] = "BBB"
 
@@ -166,8 +166,8 @@ func Test_matchesAnyRule_NotOneOfOperatorCaseInsensitive(t *testing.T) {
 }
 
 func Test_matchesAnyRule_OneOfOperatorWithString(t *testing.T) {
-	oneOfRule := rule{conditions: []condition{{operator: "ONE_OF", value: []string{"john", "ron"}, attribute: "name"}}}
-	notOneOfRule := rule{conditions: []condition{{operator: "NOT_ONE_OF", value: []string{"ron"}, attribute: "name"}}}
+	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"john", "ron"}, Attribute: "name"}}}
+	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"ron"}, Attribute: "name"}}}
 
 	subjectAttributesJohn := make(dictionary)
 	subjectAttributesJohn["name"] = "john"
@@ -194,8 +194,8 @@ func Test_matchesAnyRule_OneOfOperatorWithString(t *testing.T) {
 }
 
 func Test_matchesAnyRule_OneOfOperatorWithNumber(t *testing.T) {
-	oneOfRule := rule{conditions: []condition{{operator: "ONE_OF", value: []string{"14", "15.11", "15"}, attribute: "number"}}}
-	notOneOfRule := rule{conditions: []condition{{operator: "NOT_ONE_OF", value: []string{"10"}, attribute: "number"}}}
+	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"14", "15.11", "15"}, Attribute: "number"}}}
+	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"10"}, Attribute: "number"}}}
 
 	subjectAttributes0 := make(dictionary)
 	subjectAttributes0["number"] = "14"
@@ -272,18 +272,18 @@ func Test_isNotOneOf_Fail(t *testing.T) {
 
 func Test_evaluateNumericCondition_Success(t *testing.T) {
 	expected := false
-	result := evaluateNumericCondition(40, condition{operator: "LT", value: 30.0})
+	result := evaluateNumericCondition(40, condition{Operator: "LT", Value: 30.0})
 
 	assert.Equal(t, expected, result)
 }
 
 func Test_evaluateNumericCondition_Fail(t *testing.T) {
 	expected := true
-	result := evaluateNumericCondition(25, condition{operator: "LT", value: 30.0})
+	result := evaluateNumericCondition(25, condition{Operator: "LT", Value: 30.0})
 
 	assert.Equal(t, expected, result)
 }
 
 func Test_evaluateNumericCondition_IncorrectOperator(t *testing.T) {
-	assert.Panics(t, func() { evaluateNumericCondition(25, condition{operator: "LTGT", value: 30.0}) })
+	assert.Panics(t, func() { evaluateNumericCondition(25, condition{Operator: "LTGT", Value: 30.0}) })
 }

--- a/eppoclient/utils.go
+++ b/eppoclient/utils.go
@@ -7,7 +7,13 @@ type testData struct {
 	PercentExposure     float32              `json:"percentExposure"`
 	Variations          []testDataVariations `json:"variations"`
 	Subjects            []string             `json:"subjects"`
+	SubjectsWithAttributes []subjectWithAttributes `json:"subjectsWithAttributes"`
 	ExpectedAssignments []string             `json:"expectedAssignments"`
+}
+
+type subjectWithAttributes struct {
+	SubjectKey string `json:"subjectKey"`
+	SubjectAttributes dictionary `json:"subjectAttributes"`
 }
 
 type testDataVariations struct {


### PR DESCRIPTION
Fixes Eppo-exp/eppo#4616

- Updated the E2E tests to use the new test data, which includes test cases for targeting rules
- There was a bug where the configuration requestor always deserialized the rules as an empty array. This is because the rule properties where missing a `json` annotation.