### PR TITLE
Migrate Go SDK to V2 Randomization Endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ eppo-golang-sdk-*
 # Dependency directories (remove the comment below to include it)
 # vendor/
 eppoclient/test-data/assignment-v2
-eppoclient/test-data/rac-experiments.json
+eppoclient/test-data/rac-experiments-v2.json
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ testDataDir := eppoclient/test-data/
 test-data:
 	rm -rf $(testDataDir)
 	mkdir -p $(testDataDir)
-	gsutil cp gs://sdk-test-data/rac-experiments.json $(testDataDir)
+	gsutil cp gs://sdk-test-data/rac-experiments-v2.json $(testDataDir)
 	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
 
 test: test-data

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -77,7 +77,7 @@ func (ec *EppoClient) GetAssignment(subjectKey string, flagKey string, subjectAt
 		}
 	}
 
-	assignedVariation := variationShard.Value.(string)
+	assignedVariation := variationShard.Value.StringValue()
 
 	assignmentEvent := AssignmentEvent{
 		Experiment:        flagKey,

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+var defaultAllocationKey = "allocation-key"
+var defaultRule = rule{Conditions: []condition{}, AllocationKey: defaultAllocationKey}
+
 func Test_AssignBlankExperiment(t *testing.T) {
 	var mockConfigRequestor = new(mockConfigRequestor)
 	var mockLogger = new(mockLogger)
@@ -30,13 +33,18 @@ func Test_SubjectNotInSample(t *testing.T) {
 	var mockVariations = []Variation{
 		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
 	}
-	mockResult := experimentConfiguration{
-		Name:            "recommendation_algo",
+	var allocations = make(map[string]Allocation)
+	allocations[defaultAllocationKey] = Allocation{
 		PercentExposure: 0,
-		Enabled:         true,
-		SubjectShards:   1000,
-		Overrides:       overrides,
 		Variations:      mockVariations,
+	}
+	mockResult := experimentConfiguration{
+		Name:          "recommendation_algo",
+		Enabled:       true,
+		SubjectShards: 1000,
+		Overrides:     overrides,
+		Allocations:   allocations,
+		Rules:         []rule{defaultRule},
 	}
 
 	mockConfigRequestor.Mock.On("GetConfiguration", mock.Anything).Return(mockResult, nil)
@@ -59,13 +67,18 @@ func Test_LogAssignment(t *testing.T) {
 	var mockVariations = []Variation{
 		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
 	}
-	mockResult := experimentConfiguration{
-		Name:            "recommendation_algo",
-		PercentExposure: 100,
-		Enabled:         true,
-		SubjectShards:   1000,
-		Overrides:       overrides,
+	var allocations = make(map[string]Allocation)
+	allocations[defaultAllocationKey] = Allocation{
+		PercentExposure: 1,
 		Variations:      mockVariations,
+	}
+	mockResult := experimentConfiguration{
+		Name:          "recommendation_algo",
+		Enabled:       true,
+		SubjectShards: 1000,
+		Overrides:     overrides,
+		Allocations:   allocations,
+		Rules:         []rule{defaultRule},
 	}
 	mockConfigRequestor.Mock.On("GetConfiguration", "experiment-key-1").Return(mockResult, nil)
 
@@ -89,13 +102,18 @@ func Test_GetAssignmentHandlesLoggingPanic(t *testing.T) {
 	var mockVariations = []Variation{
 		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
 	}
-	mockResult := experimentConfiguration{
-		Name:            "recommendation_algo",
-		PercentExposure: 100,
-		Enabled:         true,
-		SubjectShards:   1000,
-		Overrides:       overrides,
+	var allocations = make(map[string]Allocation)
+	allocations[defaultAllocationKey] = Allocation{
+		PercentExposure: 1,
 		Variations:      mockVariations,
+	}
+	mockResult := experimentConfiguration{
+		Name:          "recommendation_algo",
+		Enabled:       true,
+		SubjectShards: 1000,
+		Overrides:     overrides,
+		Allocations:   allocations,
+		Rules:         []rule{defaultRule},
 	}
 	mockConfigRequestor.Mock.On("GetConfiguration", "experiment-key-1").Return(mockResult, nil)
 
@@ -113,20 +131,24 @@ func Test_AssignSubjectWithAttributesAndRules(t *testing.T) {
 	mockLogger.Mock.On("LogAssignment", mock.Anything).Return()
 
 	var matchesEmailCondition = condition{Operator: "MATCHES", Value: ".*@eppo.com", Attribute: "email"}
-	var textRule = rule{Conditions: []condition{matchesEmailCondition}}
+	var textRule = rule{AllocationKey: defaultAllocationKey, Conditions: []condition{matchesEmailCondition}}
 	var mockConfigRequestor = new(mockConfigRequestor)
 	var overrides = make(dictionary)
 	var mockVariations = []Variation{
 		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
 	}
-	var mockResult = experimentConfiguration{
-		Name:            "recommendation_algo",
-		PercentExposure: 100,
-		Enabled:         true,
-		SubjectShards:   1000,
-		Overrides:       overrides,
+	var allocations = make(map[string]Allocation)
+	allocations[defaultAllocationKey] = Allocation{
+		PercentExposure: 1,
 		Variations:      mockVariations,
-		Rules:           []rule{textRule},
+	}
+	var mockResult = experimentConfiguration{
+		Name:          "recommendation_algo",
+		Enabled:       true,
+		SubjectShards: 1000,
+		Overrides:     overrides,
+		Rules:         []rule{textRule},
+		Allocations:   allocations,
 	}
 	mockConfigRequestor.Mock.On("GetConfiguration", "experiment-key-1").Return(mockResult, nil)
 
@@ -164,14 +186,17 @@ func Test_WithSubjectInOverrides(t *testing.T) {
 	}
 	var overrides = make(dictionary)
 	overrides["d6d7705392bc7af633328bea8c4c6904"] = "override-variation"
-	var mockResult = experimentConfiguration{
-		Name:            "recommendation_algo",
-		PercentExposure: 100,
-		Enabled:         true,
-		SubjectShards:   1000,
-		Overrides:       overrides,
+	var allocations = make(map[string]Allocation)
+	allocations[defaultAllocationKey] = Allocation{
+		PercentExposure: 1,
 		Variations:      mockVariations,
-		Rules:           []rule{textRule},
+	}
+	var mockResult = experimentConfiguration{
+		Name:          "recommendation_algo",
+		Enabled:       true,
+		SubjectShards: 1000,
+		Overrides:     overrides,
+		Rules:         []rule{textRule},
 	}
 
 	mockConfigRequestor.Mock.On("GetConfiguration", "experiment-key-1").Return(mockResult, nil)
@@ -193,14 +218,18 @@ func Test_WithSubjectInOverridesExpDisabled(t *testing.T) {
 	}
 	var overrides = make(dictionary)
 	overrides["d6d7705392bc7af633328bea8c4c6904"] = "override-variation"
-	var mockResult = experimentConfiguration{
-		Name:            "recommendation_algo",
-		PercentExposure: 100,
-		Enabled:         false,
-		SubjectShards:   1000,
-		Overrides:       overrides,
+	var allocations = make(map[string]Allocation)
+	allocations[defaultAllocationKey] = Allocation{
+		PercentExposure: 1,
 		Variations:      mockVariations,
-		Rules:           []rule{textRule},
+	}
+	var mockResult = experimentConfiguration{
+		Name:          "recommendation_algo",
+		Enabled:       false,
+		SubjectShards: 1000,
+		Overrides:     overrides,
+		Allocations:   allocations,
+		Rules:         []rule{textRule},
 	}
 
 	mockConfigRequestor.Mock.On("GetConfiguration", "experiment-key-1").Return(mockResult, nil)

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -31,7 +31,7 @@ func Test_SubjectNotInSample(t *testing.T) {
 	var mockConfigRequestor = new(mockConfigRequestor)
 	overrides := make(dictionary)
 	var mockVariations = []Variation{
-		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
+		{Name: "control", Value: String("control"), ShardRange: shardRange{Start: 0, End: 10000}},
 	}
 	var allocations = make(map[string]Allocation)
 	allocations[defaultAllocationKey] = Allocation{
@@ -65,7 +65,7 @@ func Test_LogAssignment(t *testing.T) {
 	overrides := make(dictionary)
 
 	var mockVariations = []Variation{
-		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
+		{Name: "control", Value: String("control"), ShardRange: shardRange{Start: 0, End: 10000}},
 	}
 	var allocations = make(map[string]Allocation)
 	allocations[defaultAllocationKey] = Allocation{
@@ -100,7 +100,7 @@ func Test_GetAssignmentHandlesLoggingPanic(t *testing.T) {
 	overrides := make(dictionary)
 
 	var mockVariations = []Variation{
-		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
+		{Name: "control", Value: String("control"), ShardRange: shardRange{Start: 0, End: 10000}},
 	}
 	var allocations = make(map[string]Allocation)
 	allocations[defaultAllocationKey] = Allocation{
@@ -135,7 +135,7 @@ func Test_AssignSubjectWithAttributesAndRules(t *testing.T) {
 	var mockConfigRequestor = new(mockConfigRequestor)
 	var overrides = make(dictionary)
 	var mockVariations = []Variation{
-		{Name: "control", ShardRange: shardRange{Start: 0, End: 10000}},
+		{Name: "control", Value: String("control"), ShardRange: shardRange{Start: 0, End: 10000}},
 	}
 	var allocations = make(map[string]Allocation)
 	allocations[defaultAllocationKey] = Allocation{

--- a/eppoclient/configurationrequestor.go
+++ b/eppoclient/configurationrequestor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-const RAC_ENDPOINT = "/randomized_assignment/config"
+const RAC_ENDPOINT = "/randomized_assignment/v2/config"
 
 type iConfigRequestor interface {
 	GetConfiguration(key string) (experimentConfiguration, error)
@@ -48,7 +48,7 @@ func (ecr *experimentConfigurationRequestor) FetchAndStoreConfigurations() {
 		fmt.Println(err)
 	}
 
-	err = json.Unmarshal(responseBody["experiments"], &configs)
+	err = json.Unmarshal(responseBody["flags"], &configs)
 
 	if err != nil {
 		fmt.Println("Failed to unmarshal RAC response json in experiments section", result)

--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -13,9 +13,9 @@ type configurationStore struct {
 }
 
 type Variation struct {
-	Name       string      `json:"name"`
-	Value      interface{} `json:"value"`
-	ShardRange shardRange
+	Name       string     `json:"name"`
+	Value      Value      `json:"value"`
+	ShardRange shardRange `json:"shardRange"`
 }
 
 type Allocation struct {

--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -13,18 +13,23 @@ type configurationStore struct {
 }
 
 type Variation struct {
-	Name       string `json:"name"`
+	Name       string      `json:"name"`
+	Value      interface{} `json:"value"`
 	ShardRange shardRange
 }
 
-type experimentConfiguration struct {
-	Name            string      `json:"name"`
+type Allocation struct {
 	PercentExposure float32     `json:"percentExposure"`
-	Enabled         bool        `json:"enabled"`
-	SubjectShards   int         `json:"subjectShards"`
 	Variations      []Variation `json:"variations"`
-	Rules           []rule      `json:"rules"`
-	Overrides       dictionary  `json:"overrides"`
+}
+
+type experimentConfiguration struct {
+	Name          string                `json:"name"`
+	Enabled       bool                  `json:"enabled"`
+	SubjectShards int                   `json:"subjectShards"`
+	Rules         []rule                `json:"rules"`
+	Overrides     dictionary            `json:"overrides"`
+	Allocations   map[string]Allocation `json:"allocations"`
 }
 
 func newConfigurationStore(maxEntries int) *configurationStore {

--- a/eppoclient/configurationstore_test.go
+++ b/eppoclient/configurationstore_test.go
@@ -7,12 +7,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var testAllocationMap = make(map[string]Allocation)
+
 var testExp = experimentConfiguration{
-	SubjectShards:   1000,
-	PercentExposure: 1,
-	Enabled:         true,
-	Variations:      []Variation{},
-	Name:            "randomization_algo",
+	SubjectShards: 1000,
+	Enabled:       true,
+	Allocations:   testAllocationMap,
+	Rules:         []rule{},
+	Name:          "randomization_algo",
 }
 
 const TEST_MAX_SIZE = 10

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const TEST_DATA_DIR = "test-data/assignment-v2"
-const MOCK_RAC_RESPONSE_FILE = "test-data/rac-experiments.json"
+const MOCK_RAC_RESPONSE_FILE = "test-data/rac-experiments-v2.json"
 
 var tstData = []testData{}
 
@@ -61,7 +61,7 @@ func initFixture() string {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimSpace(r.URL.Path) {
-		case "/randomized_assignment/config":
+		case "/randomized_assignment/v2/config":
 			json.NewEncoder(w).Encode(testResponse)
 		default:
 			http.NotFoundHandler().ServeHTTP(w, r)

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -4,7 +4,7 @@ package eppoclient
 
 import "net/http"
 
-var __version__ = "1.0.0"
+var __version__ = "1.1.0"
 
 // InitClient is required to start polling of experiments configurations and create
 // an instance of EppoClient, which could be used to get assignments information.

--- a/eppoclient/rules.go
+++ b/eppoclient/rules.go
@@ -30,16 +30,6 @@ func findMatchingRule(subjectAttributes dictionary, rules []rule) (rule, error) 
 	return rule{}, errors.New("No matching rule")
 }
 
-func matchesAnyRule(subjectAttributes dictionary, rules []rule) bool {
-	for _, rule := range rules {
-		if matchesRule(subjectAttributes, rule) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func matchesRule(subjectAttributes dictionary, rule rule) bool {
 	for _, condition := range rule.Conditions {
 		if !evaluateCondition(subjectAttributes, condition) {

--- a/eppoclient/rules.go
+++ b/eppoclient/rules.go
@@ -1,6 +1,7 @@
 package eppoclient
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -15,7 +16,18 @@ type condition struct {
 }
 
 type rule struct {
-	Conditions []condition `json:"conditions"`
+	AllocationKey string      `json:"allocationKey"`
+	Conditions    []condition `json:"conditions"`
+}
+
+func findMatchingRule(subjectAttributes dictionary, rules []rule) (rule, error) {
+	for _, rule := range rules {
+		if matchesRule(subjectAttributes, rule) {
+			return rule, nil
+		}
+	}
+
+	return rule{}, errors.New("No matching rule")
 }
 
 func matchesAnyRule(subjectAttributes dictionary, rules []rule) bool {

--- a/eppoclient/rules_test.go
+++ b/eppoclient/rules_test.go
@@ -13,95 +13,83 @@ var numericRule = rule{Conditions: []condition{greaterThanCondition, lessThanCon
 var matchesEmailCondition = condition{Operator: "MATCHES", Value: ".*@email.com", Attribute: "email"}
 var textRule = rule{Conditions: []condition{matchesEmailCondition}}
 var ruleWithEmptyConditions = rule{Conditions: []condition{}}
+var expectedNoMatchErrorMessage = "No matching rule"
 
-func Test_matchesAnyRule_withEmptyRules(t *testing.T) {
-	expected := false
-
+func Test_findMatchingRule_withEmptyRules(t *testing.T) {
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 20
 	subjectAttributes["country"] = "US"
 
-	result := matchesAnyRule(subjectAttributes, []rule{})
+	_, err := findMatchingRule(subjectAttributes, []rule{})
 
-	assert.Equal(t, expected, result)
+	assert.EqualError(t, err, expectedNoMatchErrorMessage)
 }
 
-func Test_matchesAnyRule_whenNoRulesMatch(t *testing.T) {
-	expected := false
-
+func Test_findMatchingRule_whenNoRulesMatch(t *testing.T) {
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 99
 	subjectAttributes["country"] = "US"
 	subjectAttributes["email"] = "test@example.com"
 
-	result := matchesAnyRule(subjectAttributes, []rule{textRule})
+	_, err := findMatchingRule(subjectAttributes, []rule{textRule})
 
-	assert.Equal(t, expected, result)
+	assert.EqualError(t, err, expectedNoMatchErrorMessage)
 }
 
-func Test_matchesAnyRule_Success(t *testing.T) {
-	expected := true
-
+func Test_findMatchingRule_Success(t *testing.T) {
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 99.0
 
-	result := matchesAnyRule(subjectAttributes, []rule{numericRule})
+	result, _ := findMatchingRule(subjectAttributes, []rule{numericRule})
 
-	assert.Equal(t, expected, result)
+	assert.Equal(t, numericRule, result)
 }
 
-func Test_matchesAnyRule_NoAttributeForCondition(t *testing.T) {
-	expected := false
-
+func Test_findMatchingRule_NoAttributeForCondition(t *testing.T) {
 	subjectAttributes := make(dictionary)
 
-	result := matchesAnyRule(subjectAttributes, []rule{numericRule})
+	_, err := findMatchingRule(subjectAttributes, []rule{numericRule})
 
-	assert.Equal(t, expected, result)
+	assert.EqualError(t, err, expectedNoMatchErrorMessage)
 }
 
-func Test_matchesAnyRule_NoConditionsForRule(t *testing.T) {
-	expected := true
-
+func Test_findMatchingRule_NoConditionsForRule(t *testing.T) {
 	subjectAttributes := make(dictionary)
 
-	result := matchesAnyRule(subjectAttributes, []rule{ruleWithEmptyConditions})
+	result, _ := findMatchingRule(subjectAttributes, []rule{ruleWithEmptyConditions})
 
-	assert.Equal(t, expected, result)
+	assert.Equal(t, ruleWithEmptyConditions, result)
 }
 
-func Test_matchesAnyRule_NumericOperatorWithString(t *testing.T) {
-	expected := false
-
+func Test_findMatchingRule_NumericOperatorWithString(t *testing.T) {
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = "something"
 
-	result := matchesAnyRule(subjectAttributes, []rule{numericRule})
+	_, err := findMatchingRule(subjectAttributes, []rule{numericRule})
 
-	assert.Equal(t, expected, result)
+	assert.EqualError(t, err, expectedNoMatchErrorMessage)
 }
 
-func Test_matchesAnyRule_NumericValueAndRegex(t *testing.T) {
-	expected := true
-
+func Test_findMatchingRule_NumericValueAndRegex(t *testing.T) {
 	cdn := condition{Operator: "MATCHES", Value: "[0-9]+", Attribute: "age"}
 	rl := rule{Conditions: []condition{cdn}}
 
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 99
 
-	result := matchesAnyRule(subjectAttributes, []rule{rl})
+	result, _ := findMatchingRule(subjectAttributes, []rule{rl})
 
-	assert.Equal(t, expected, result)
+	assert.Equal(t, rl, result)
 }
 
 type MatchesAnyRuleTest []struct {
 	a    dictionary
 	b    []rule
-	want bool
+	expectedRule rule
+	expectedError string
 }
 
-func Test_matchesAnyRule_oneOfOperatorWithBoolean(t *testing.T) {
+func Test_findMatchingRule_oneOfOperatorWithBoolean(t *testing.T) {
 	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"true"}, Attribute: "enabled"}}}
 	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"True"}, Attribute: "enabled"}}}
 
@@ -112,20 +100,23 @@ func Test_matchesAnyRule_oneOfOperatorWithBoolean(t *testing.T) {
 	subjectAttributesDisabled["enabled"] = "false"
 
 	var tests = MatchesAnyRuleTest{
-		{subjectAttributesEnabled, []rule{oneOfRule}, true},
-		{subjectAttributesDisabled, []rule{oneOfRule}, false},
-		{subjectAttributesEnabled, []rule{notOneOfRule}, false},
-		{subjectAttributesDisabled, []rule{notOneOfRule}, true},
+		{subjectAttributesEnabled, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributesDisabled, []rule{oneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributesEnabled, []rule{notOneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributesDisabled, []rule{notOneOfRule}, notOneOfRule, ""},
 	}
 
 	for _, tt := range tests {
-		result := matchesAnyRule(tt.a, tt.b)
+		result, err := findMatchingRule(tt.a, tt.b)
 
-		assert.Equal(t, tt.want, result)
+		assert.Equal(t, tt.expectedRule, result)
+		if tt.expectedError != "" {
+			assert.EqualError(t, err, tt.expectedError)
+		}
 	}
 }
 
-func Test_matchesAnyRule_OneOfOperatorCaseInsensitive(t *testing.T) {
+func Test_findMatchingRule_OneOfOperatorCaseInsensitive(t *testing.T) {
 	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"1Ab", "Ron"}, Attribute: "name"}}}
 	subjectAttributes0 := make(dictionary)
 	subjectAttributes0["name"] = "ron"
@@ -134,18 +125,21 @@ func Test_matchesAnyRule_OneOfOperatorCaseInsensitive(t *testing.T) {
 	subjectAttributes1["name"] = "1AB"
 
 	var tests = MatchesAnyRuleTest{
-		{subjectAttributes0, []rule{oneOfRule}, true},
-		{subjectAttributes1, []rule{oneOfRule}, true},
+		{subjectAttributes0, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributes1, []rule{oneOfRule}, oneOfRule, ""},
 	}
 
 	for _, tt := range tests {
-		result := matchesAnyRule(tt.a, tt.b)
+		result, err := findMatchingRule(tt.a, tt.b)
 
-		assert.Equal(t, tt.want, result)
+		assert.Equal(t, tt.expectedRule, result)
+		if (tt.expectedError != "") {
+			assert.EqualError(t, err, tt.expectedError)
+		}
 	}
 }
 
-func Test_matchesAnyRule_NotOneOfOperatorCaseInsensitive(t *testing.T) {
+func Test_findMatchingRule_NotOneOfOperatorCaseInsensitive(t *testing.T) {
 	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"bbB", "1.1.ab"}, Attribute: "name"}}}
 	subjectAttributes0 := make(dictionary)
 	subjectAttributes0["name"] = "BBB"
@@ -154,18 +148,19 @@ func Test_matchesAnyRule_NotOneOfOperatorCaseInsensitive(t *testing.T) {
 	subjectAttributes1["name"] = "1.1.AB"
 
 	var tests = MatchesAnyRuleTest{
-		{subjectAttributes0, []rule{notOneOfRule}, false},
-		{subjectAttributes1, []rule{notOneOfRule}, false},
+		{subjectAttributes0, []rule{notOneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributes1, []rule{notOneOfRule}, rule{}, expectedNoMatchErrorMessage},
 	}
 
 	for _, tt := range tests {
-		result := matchesAnyRule(tt.a, tt.b)
+		result, err := findMatchingRule(tt.a, tt.b)
 
-		assert.Equal(t, tt.want, result)
+		assert.Equal(t, tt.expectedRule, result)
+		assert.EqualError(t, err, tt.expectedError)
 	}
 }
 
-func Test_matchesAnyRule_OneOfOperatorWithString(t *testing.T) {
+func Test_findMatchingRule_OneOfOperatorWithString(t *testing.T) {
 	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"john", "ron"}, Attribute: "name"}}}
 	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"ron"}, Attribute: "name"}}}
 
@@ -179,21 +174,24 @@ func Test_matchesAnyRule_OneOfOperatorWithString(t *testing.T) {
 	subjectAttributesSam["name"] = "sam"
 
 	var tests = MatchesAnyRuleTest{
-		{subjectAttributesJohn, []rule{oneOfRule}, true},
-		{subjectAttributesRon, []rule{oneOfRule}, true},
-		{subjectAttributesSam, []rule{oneOfRule}, false},
-		{subjectAttributesRon, []rule{notOneOfRule}, false},
-		{subjectAttributesSam, []rule{notOneOfRule}, true},
+		{subjectAttributesJohn, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributesRon, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributesSam, []rule{oneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributesRon, []rule{notOneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributesSam, []rule{notOneOfRule}, notOneOfRule, ""},
 	}
 
 	for _, tt := range tests {
-		result := matchesAnyRule(tt.a, tt.b)
+		result, err := findMatchingRule(tt.a, tt.b)
 
-		assert.Equal(t, tt.want, result)
+		assert.Equal(t, tt.expectedRule, result)
+		if (tt.expectedError != "") {
+			assert.EqualError(t, err, tt.expectedError)
+		}
 	}
 }
 
-func Test_matchesAnyRule_OneOfOperatorWithNumber(t *testing.T) {
+func Test_findMatchingRule_OneOfOperatorWithNumber(t *testing.T) {
 	oneOfRule := rule{Conditions: []condition{{Operator: "ONE_OF", Value: []string{"14", "15.11", "15"}, Attribute: "number"}}}
 	notOneOfRule := rule{Conditions: []condition{{Operator: "NOT_ONE_OF", Value: []string{"10"}, Attribute: "number"}}}
 
@@ -213,18 +211,21 @@ func Test_matchesAnyRule_OneOfOperatorWithNumber(t *testing.T) {
 	subjectAttributes4["number"] = 11
 
 	var tests = MatchesAnyRuleTest{
-		{subjectAttributes0, []rule{oneOfRule}, true},
-		{subjectAttributes1, []rule{oneOfRule}, true},
-		{subjectAttributes2, []rule{oneOfRule}, true},
-		{subjectAttributes3, []rule{oneOfRule}, false},
-		{subjectAttributes3, []rule{notOneOfRule}, false},
-		{subjectAttributes4, []rule{notOneOfRule}, true},
+		{subjectAttributes0, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributes1, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributes2, []rule{oneOfRule}, oneOfRule, ""},
+		{subjectAttributes3, []rule{oneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributes3, []rule{notOneOfRule}, rule{}, expectedNoMatchErrorMessage},
+		{subjectAttributes4, []rule{notOneOfRule}, notOneOfRule, ""},
 	}
 
 	for _, tt := range tests {
-		result := matchesAnyRule(tt.a, tt.b)
+		result, err := findMatchingRule(tt.a, tt.b)
 
-		assert.Equal(t, tt.want, result)
+		assert.Equal(t, tt.expectedRule, result)
+		if (tt.expectedError != "") {
+			assert.EqualError(t, err, tt.expectedError)
+		}
 	}
 }
 

--- a/eppoclient/rules_test.go
+++ b/eppoclient/rules_test.go
@@ -11,7 +11,7 @@ var lessThanCondition = condition{Operator: "LT", Value: 100.0, Attribute: "age"
 var numericRule = rule{Conditions: []condition{greaterThanCondition, lessThanCondition}}
 
 var matchesEmailCondition = condition{Operator: "MATCHES", Value: ".*@email.com", Attribute: "email"}
-var textRule = rule{Conditions: []condition{matchesEmailCondition}}
+var textRule = rule{AllocationKey: "allocation-key", Conditions: []condition{matchesEmailCondition}}
 var ruleWithEmptyConditions = rule{Conditions: []condition{}}
 var expectedNoMatchErrorMessage = "No matching rule"
 

--- a/eppoclient/value.go
+++ b/eppoclient/value.go
@@ -1,0 +1,82 @@
+package eppoclient
+
+import (
+	"encoding/json"
+)
+
+type ValueType int
+
+const (
+	NullType   ValueType = iota
+	BoolType   ValueType = iota
+	StringType ValueType = iota
+)
+
+type Value struct {
+	valueType ValueType
+	stringValue string
+	boolValue   bool
+}
+
+func Null() Value {
+	return Value{valueType: NullType}
+}
+
+func Bool(value bool) Value {
+	return Value{valueType: BoolType, boolValue: value}
+}
+
+func String(value string) Value {
+	return Value{valueType: StringType, stringValue: value}
+}
+
+func (receiver *Value) UnmarshalJSON(data []byte) error {
+	var valueInterface interface{}  
+	if err := json.Unmarshal(data, &valueInterface); err != nil {
+		return err
+	}
+	*receiver = castInterfaceToValue(valueInterface)
+	return nil
+}
+
+func castInterfaceToValue(valueInterface interface{}) Value {
+	if valueInterface == nil {
+		return Null()
+	}
+	switch v := valueInterface.(type) {
+	case Value:
+		return v
+	case *Value:
+		if v == nil {
+			return Null()
+		}
+		return *v
+	case bool:
+		return Bool(v)
+	case *bool:
+		if v == nil {
+			return Null()
+		}
+		return Bool(*v)
+	case string:
+		return String(v)
+	case *string:
+		if v == nil {
+			return Null()
+		}
+		return String(*v)
+	default:
+		return Null()
+	}
+}
+
+func (v Value) StringValue() string {
+	if v.valueType == StringType {
+		return v.stringValue
+	}
+	return ""
+}
+
+func (v Value) BoolValue() bool {
+	return v.valueType == BoolType && v.boolValue
+}


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes Eppo-exp/eppo#4711

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Design Doc: https://www.notion.so/eppo/Feature-Flagging-API-Design-d768a09de1194cebb04ef8af157fda57

## Description
[//]: # (Describe your changes in detail)

Updated the `getAssignment` logic to use the **allocation** (variations + exposure) for the matched targeting rule. The API response inserts a default rule that always matches if the experiment does not have any rules.

See the above design doc for details

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

- Updated the e2e tests to use new test data for the V2 RAC response.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
