### PR TITLE
Increase timeout to 10 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This version of the SDK is compatible with Go v1.18 and above.
 	func main() {
 		eppoClient = eppoclient.InitClient(eppoclient.Config{
 			ApiKey:           "<your_api_key>",
-			BaseUrl:          "<base_url>", // optional, default https://eppo.cloud/api
+			BaseUrl:          "<base_url>", // optional, default https://fscdn.eppo.cloud/api
 			AssignmentLogger: eppoclient.AssignmentLogger{},
 		})
 	}

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Client for eppo.cloud. Instance of this struct will be created on calling InitClient.
-// EppoClient will then immediately start polling experiments data from eppo.cloud.
+// EppoClient will then immediately start polling experiments data from Eppo.
 type EppoClient struct {
 	configRequestor iConfigRequestor
 	poller          poller

--- a/eppoclient/doc.go
+++ b/eppoclient/doc.go
@@ -14,7 +14,6 @@
 	func main() {
 		eppoClient = eppoclient.InitClient(eppoclient.Config{
 			ApiKey:           "<your_api_key>",
-			BaseUrl:          "<eppo.cloud>",
 			AssignmentLogger: eppoclient.AssignmentLogger{},
 		})
 	}
@@ -22,7 +21,7 @@
 	func apiEndpoint() {
 		assignment, _ := eppoClient.GetAssignment("subject-1", "experiment_5", sbjAttrs)
 
-		if assigment == "control" {
+		if assignment == "control" {
 			// do something
 		}
 	}

--- a/eppoclient/httpclient.go
+++ b/eppoclient/httpclient.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-const REQUEST_TIMEOUT_SECONDS = time.Duration(1 * time.Second)
+const REQUEST_TIMEOUT_SECONDS = time.Duration(10 * time.Second)
 
 type httpClient struct {
 	baseUrl        string


### PR DESCRIPTION
The default timeout of 1 second can cause initialization to fail if the config is not populated in any caches. 