### PR TITLE
add Get*Assignment methods with types (FF-757)

### DIFF
--- a/.github/workflows/golang-lint.yml
+++ b/.github/workflows/golang-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test-sdk.yml
+++ b/.github/workflows/test-sdk.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Build
         run: go build -v ./...
       - name: 'Set up GCP SDK for downloading test data'

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ eppo-golang-sdk-*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-eppoclient/test-data/assignment-v2
-eppoclient/test-data/rac-experiments-v2.json
+eppoclient/test-data
 .vscode
+
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Get Eppo
+Copyright (c) 2023 Eppo Data
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ testDataDir := eppoclient/test-data/
 test-data:
 	rm -rf $(testDataDir)
 	mkdir -p $(testDataDir)
-	gsutil cp gs://sdk-test-data/rac-experiments-v2.json $(testDataDir)
+	gsutil cp gs://sdk-test-data/rac-experiments-v3.json $(testDataDir)
 	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
 
 test: test-data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Eppo SDK for Golang
 
-Eppoclient is a client sdk for `eppo.cloud` randomization API.
+EppoClient is a client sdk for the `eppo.cloud` randomization API.
 It is used to retrieve the experiments data and put it to in-memory cache, and then get assignments information.
 
 ## Getting Started
@@ -8,7 +8,7 @@ It is used to retrieve the experiments data and put it to in-memory cache, and t
 Refer to our [SDK documentation](https://docs.geteppo.com/feature-flags/sdks/server-sdks/go) for how to install and use the SDK.
 
 ## Supported Go Versions
-This version of the SDK is compatible with Go v1.18 and above.
+This version of the SDK is compatible with Go v1.19 and above.
 
 ## Example
 
@@ -28,7 +28,7 @@ This version of the SDK is compatible with Go v1.18 and above.
 	}
 
 	func someBLFunc() {
-		assignment, _ := eppoClient.GetAssignment("subject-1", "experiment_5", sbjAttrs)
+		assignment, _ := eppoClient.GetStringAssignment("subject-1", "experiment_5", sbjAttrs)
 
 		if assignment == "control" {
 			// do something

--- a/eppoclient/assignmentlogger.go
+++ b/eppoclient/assignmentlogger.go
@@ -8,7 +8,7 @@ type IAssignmentLogger interface {
 
 type AssignmentEvent struct {
 	Experiment        string
-	Variation         string
+	Variation         Value
 	Subject           string
 	Timestamp         string
 	SubjectAttributes dictionary

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -189,15 +189,14 @@ func Test_AssignSubjectWithAttributesAndRules(t *testing.T) {
 
 func Test_WithSubjectInOverrides(t *testing.T) {
 	var tests = []struct {
-		name               string
-		input              Value
-		inputUnwantedValue Value
-		inputValueType     ValueType
-		want               Value
+		name                        string
+		inputVariationOverrideValue Value
+		inputValueType              ValueType
+		want                        Value
 	}{
-		{"string override", String("override-variation"), String("foo"), StringType, String("override-variation")},
-		{"numeric override", Numeric(5), Numeric(100), NumericType, Numeric(5)},
-		{"boolean override", Bool(true), Bool(false), BoolType, Bool(true)},
+		{"string override", String("variation-value"), StringType, String("variation-value")},
+		{"numeric override", Numeric(5), NumericType, Numeric(5)},
+		{"boolean override", Bool(true), BoolType, Bool(true)},
 	}
 
 	for _, tt := range tests {
@@ -208,10 +207,10 @@ func Test_WithSubjectInOverrides(t *testing.T) {
 
 			var mockConfigRequestor = new(mockConfigRequestor)
 			var mockVariations = []Variation{
-				{Name: "control", Value: tt.inputUnwantedValue, ShardRange: shardRange{Start: 0, End: 100}},
+				{Name: "control", ShardRange: shardRange{Start: 0, End: 100}},
 			}
 			overrides := make(map[string]Value)
-			overrides["d6d7705392bc7af633328bea8c4c6904"] = tt.input
+			overrides["d6d7705392bc7af633328bea8c4c6904"] = tt.inputVariationOverrideValue
 			var allocations = make(map[string]Allocation)
 			allocations[defaultAllocationKey] = Allocation{
 				PercentExposure: 1,
@@ -232,16 +231,19 @@ func Test_WithSubjectInOverrides(t *testing.T) {
 			switch tt.inputValueType {
 			case StringType:
 				assignment, _ := client.GetStringAssignment("user-1", "experiment-key-1", dictionary{})
+
 				if assignment != tt.want.stringValue {
 					t.Errorf("got %s, want %s", assignment, tt.want.stringValue)
 				}
 			case NumericType:
 				assignment, _ := client.GetNumericAssignment("user-1", "experiment-key-1", dictionary{})
+
 				if assignment != tt.want.numericValue {
 					t.Errorf("got %T, want %T", assignment, tt.want.numericValue)
 				}
 			case BoolType:
 				assignment, _ := client.GetBoolAssignment("user-1", "experiment-key-1", dictionary{})
+
 				if assignment != tt.want.boolValue {
 					t.Errorf("got %t, want %t", assignment, tt.want.boolValue)
 				}

--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -14,7 +14,7 @@ type configurationStore struct {
 
 type Variation struct {
 	Name       string     `json:"name"`
-	Value      Value      `json:"value"`
+	Value      Value      `json:"typedValue"`
 	ShardRange shardRange `json:"shardRange"`
 }
 
@@ -28,7 +28,7 @@ type experimentConfiguration struct {
 	Enabled       bool                  `json:"enabled"`
 	SubjectShards int                   `json:"subjectShards"`
 	Rules         []rule                `json:"rules"`
-	Overrides     dictionary            `json:"overrides"`
+	Overrides     map[string]Value      `json:"typedOverrides"`
 	Allocations   map[string]Allocation `json:"allocations"`
 }
 

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -4,7 +4,7 @@ package eppoclient
 
 import "net/http"
 
-var __version__ = "1.2.1"
+var __version__ = "2.0.0"
 
 // InitClient is required to start polling of experiments configurations and create
 // an instance of EppoClient, which could be used to get assignments information.

--- a/eppoclient/utils.go
+++ b/eppoclient/utils.go
@@ -4,11 +4,12 @@ type dictionary map[string]interface{}
 
 type testData struct {
 	Experiment             string                  `json:"experiment"`
+	ValueType              string                  `json:"valueType"`
 	PercentExposure        float32                 `json:"percentExposure"`
 	Variations             []testDataVariations    `json:"variations"`
 	Subjects               []string                `json:"subjects"`
 	SubjectsWithAttributes []subjectWithAttributes `json:"subjectsWithAttributes"`
-	ExpectedAssignments    []string                `json:"expectedAssignments"`
+	ExpectedAssignments    []Value                 `json:"expectedAssignments"`
 }
 
 type subjectWithAttributes struct {

--- a/eppoclient/value.go
+++ b/eppoclient/value.go
@@ -7,15 +7,17 @@ import (
 type ValueType int
 
 const (
-	NullType   ValueType = iota
-	BoolType   ValueType = iota
-	StringType ValueType = iota
+	NullType    ValueType = iota
+	BoolType    ValueType = iota
+	NumericType ValueType = iota
+	StringType  ValueType = iota
 )
 
 type Value struct {
-	valueType ValueType
-	stringValue string
-	boolValue   bool
+	valueType    ValueType
+	boolValue    bool
+	numericValue float64
+	stringValue  string
 }
 
 func Null() Value {
@@ -26,12 +28,16 @@ func Bool(value bool) Value {
 	return Value{valueType: BoolType, boolValue: value}
 }
 
+func Numeric(value float64) Value {
+	return Value{valueType: NumericType, numericValue: value}
+}
+
 func String(value string) Value {
 	return Value{valueType: StringType, stringValue: value}
 }
 
 func (receiver *Value) UnmarshalJSON(data []byte) error {
-	var valueInterface interface{}  
+	var valueInterface interface{}
 	if err := json.Unmarshal(data, &valueInterface); err != nil {
 		return err
 	}


### PR DESCRIPTION
## motivation

The RAC API has been updated to support typed values for variations - https://github.com/Eppo-exp/eppo/pull/7418

The GoLang SDK must be updated to support consuming these values and returning native types: `string` (including json), `float64` or `boolean`

## describe

I haven't written golang since (checks linkedin) 2020 and since then the [language has added support for generics](https://go.dev/doc/tutorial/generics). In the interest of keeping this PR a manageable size and meeting our release deadlines I have not pursued using them, instead using the `Value` struct as a container that is able to hold `string`, `float64` or `boolean` values.

**api changes**

```
+ new functions 

func (ec *EppoClient) GetBoolAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (bool, error)
func (ec *EppoClient) GetNumericAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (float64, error)
func (ec *EppoClient) GetStringAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error)
func (ec *EppoClient) GetJSONAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error)

- removed functions (breaking changes)
func (ec *EppoClient) GetAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error)
```

lint failures are fixed in: https://github.com/Eppo-exp/golang-sdk/pull/23

replace `rac-experiments-v2.json` with `rac-experiments-v3.json` - adds keys `typedOverrides` and `variations > typedValues`

```
diff eppoclient/test-data/rac-experiments-v2.json eppoclient/test-data/rac-experiments-v3.json

5a6
>       "typedOverrides": {},
19a21
>               "typedValue": "control",
27a30
>               "typedValue": "red",
35a39
>               "typedValue": "green",
47a52
>       "typedOverrides": {},
61a67
>               "typedValue": "control",
69a76
>               "typedValue": "red",
77a85
>               "typedValue": "green",
85a94
>               "typedValue": "purple",
102a112,117
>       "typedOverrides": {
>         "0bcbfc2660c78c549b0fbf870e3dc3ea": "treatment",
>         "a90ea45116d251a43da56e03d3dd7275": "control",
>         "e5cb922bc7e1a13636e361a424b4a3f3": "control",
>         "50a681dcd4046400e5c675e85b69b4ac": "control"
>       },
116a132
>               "typedValue": "control",
124a141
>               "typedValue": "treatment",
136a154
>       "typedOverrides": {},
186a205
>               "typedValue": "control",
194a214
>               "typedValue": "treatment",
202a223,269
>     },
>     "experiment_with_numeric_variations": {
>       "subjectShards": 10000,
>       "overrides": {
>         "0bcbfc2660c78c549b0fbf870e3dc3ea": "5",
>         "a90ea45116d251a43da56e03d3dd7275": "10",
>         "e5cb922bc7e1a13636e361a424b4a3f3": "10",
>         "50a681dcd4046400e5c675e85b69b4ac": "10"
>       },
>       "typedOverrides": {
>         "0bcbfc2660c78c549b0fbf870e3dc3ea": 5,
>         "a90ea45116d251a43da56e03d3dd7275": 10,
>         "e5cb922bc7e1a13636e361a424b4a3f3": 10,
>         "50a681dcd4046400e5c675e85b69b4ac": 10
>       },
>       "enabled": false,
>       "rules": [
>         {
>           "allocationKey": "allocation-experiment-5",
>           "conditions": []
>         }
>       ],
>       "allocations": {
>         "allocation-experiment-5": {
>           "percentExposure": 1,
>           "variations": [
>             {
>               "name": "control",
>               "value": "50",
>               "typedValue": 50,
>               "shardRange": {
>                 "start": 0,
>                 "end": 5000
>               }
>             },
>             {
>               "name": "treatment",
>               "value": "100",
>               "typedValue": 100,
>               "shardRange": {
>                 "start": 5000,
>                 "end": 10000
>               }
>             }
>           ]
>         }
>       }
```

## test plan

✔️  new unit test that calls 

✔️ new e2e test

* new file `assignments-v2/test-case-4.json` expects subjects to have numeric variation values

```
{
  "experiment": "experiment_with_numeric_variations",
  "valueType": "numeric",
  "subjects": [
    "subject-1",
    "subject-2",
    "subject-3",
    "subject-4"
  ],
  "expectedAssignments": [
    5,
    5,
    5,
    10
  ]
}
```