### PR TITLE
fix lint failures; upgrade deprecate io/ioutils package (FF-820)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ eppo-golang-sdk-*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
-eppoclient/test-data/assignment-v2
-eppoclient/test-data/rac-experiments-v2.json
+eppoclient/test-data
 .vscode
+
+.DS_Store

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -1,6 +1,7 @@
 package eppoclient
 
 import (
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,12 @@ func Test_AssignBlankExperiment(t *testing.T) {
 	var mockLogger = new(mockLogger)
 	client := newEppoClient(mockConfigRequestor, mockLogger)
 
-	assert.Panics(t, func() { client.GetAssignment("subject-1", "", dictionary{}) })
+	assert.Panics(t, func() {
+		_, err := client.GetAssignment("subject-1", "", dictionary{})
+		if err != nil {
+			log.Println(err)
+		}
+	})
 }
 
 func Test_AssignBlankSubject(t *testing.T) {
@@ -23,7 +29,12 @@ func Test_AssignBlankSubject(t *testing.T) {
 	var mockLogger = new(mockLogger)
 	client := newEppoClient(mockConfigRequestor, mockLogger)
 
-	assert.Panics(t, func() { client.GetAssignment("", "experiment-1", dictionary{}) })
+	assert.Panics(t, func() {
+		_, err := client.GetAssignment("", "experiment-1", dictionary{})
+		if err != nil {
+			log.Println(err)
+		}
+	})
 }
 
 func Test_SubjectNotInSample(t *testing.T) {

--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -59,7 +59,10 @@ func (cs *configurationStore) GetConfiguration(key string) (expConfig experiment
 		log.Fatalln("Incorrect json")
 	}
 	ec := experimentConfiguration{}
-	json.Unmarshal(jsonString, &ec)
+	err = json.Unmarshal(jsonString, &ec)
+	if err != nil {
+		log.Fatalln("failure to unmarshal json into experiment configuration")
+	}
 
 	return ec, nil
 }

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -3,7 +3,7 @@ package eppoclient
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -62,7 +62,10 @@ func initFixture() string {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch strings.TrimSpace(r.URL.Path) {
 		case "/randomized_assignment/v3/config":
-			json.NewEncoder(w).Encode(testResponse)
+			err := json.NewEncoder(w).Encode(testResponse)
+			if err != nil {
+				fmt.Println("Error encoding test response")
+			}
 		default:
 			http.NotFoundHandler().ServeHTTP(w, r)
 		}
@@ -72,7 +75,7 @@ func initFixture() string {
 }
 
 func getTestData() dictionary {
-	files, err := ioutil.ReadDir(TEST_DATA_DIR)
+	files, err := os.ReadDir(TEST_DATA_DIR)
 
 	if err != nil {
 		panic("test cases files read error")
@@ -88,15 +91,22 @@ func getTestData() dictionary {
 		defer jsonFile.Close()
 
 		testCaseDict := testData{}
-		byteValue, _ := ioutil.ReadAll(jsonFile)
-		json.Unmarshal(byteValue, &testCaseDict)
+		byteValue, _ := io.ReadAll(jsonFile)
+		err = json.Unmarshal(byteValue, &testCaseDict)
+		if err != nil {
+			fmt.Println("Error reading test case file")
+		}
 		tstData = append(tstData, testCaseDict)
 	}
 
 	var racResponseData map[string]interface{}
 	racResponseJsonFile, _ := os.Open(MOCK_RAC_RESPONSE_FILE)
-	byteValue, _ := ioutil.ReadAll(racResponseJsonFile)
+	byteValue, _ := io.ReadAll(racResponseJsonFile)
 	err = json.Unmarshal(byteValue, &racResponseData)
+	if err != nil {
+		fmt.Println("Error reading mock RAC response file")
+	}
+
 	if err != nil {
 		fmt.Println("Error reading mock RAC response file")
 	}

--- a/eppoclient/httpclient.go
+++ b/eppoclient/httpclient.go
@@ -23,16 +23,6 @@ type SDKParams struct {
 	sdkVersion string
 }
 
-// todo move this to requestor
-type experiment struct {
-	Name   string
-	Latest string
-}
-
-type experiments struct {
-	Results []*experiment
-}
-
 func newHttpClient(baseUrl string, client *http.Client, sdkParams SDKParams) *httpClient {
 	var hc = &httpClient{
 		baseUrl:        baseUrl,


### PR DESCRIPTION
running `make lint` on `main` branch had several errors: https://linear.app/eppo/issue/FF-820/fix-lint-errors-and-deprecations-in-golang-sdk

## test

```
➜  golang-sdk git:(lr/ff-820/lint-dep) make lint
golangci-lint run
```