### PR TITLE
add GetAssignment method back for backwards compatibility

### DIFF
--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -28,6 +28,11 @@ func newEppoClient(configRequestor iConfigRequestor, assignmentLogger IAssignmen
 	return ec
 }
 
+// GetAssignment is maintained for backwards capability. It will return a string value for the assignment.
+func (ec *EppoClient) GetAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error) {
+	return ec.GetStringAssignment(subjectKey, flagKey, subjectAttributes)
+}
+
 func (ec *EppoClient) GetBoolAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (bool, error) {
 	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, BoolType)
 	return variation.boolValue, err


### PR DESCRIPTION
## motivation

feedback from @petzel in the android sdk https://github.com/Eppo-exp/android-sdk/pull/20/files/ddd4e184376d5a11b62a269d644816d5e02ed105#diff-287964a900b019b23d779f2a2a0bddf0fc42e4d8821c3055266a4453abdf5bd9

keeping the `GetAssignment` will let people upgrade to version 2 without breaking changes.