### PR TITLE
bug: fix json variation value handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,20 @@ help: Makefile
 	@echo "usage: make <target>"
 	@sed -n 's/^##//p' $<
 
+## test-data
 testDataDir := eppoclient/test-data/
+tempDir := ${testDataDir}temp/
+gitDataDir := ${tempDir}sdk-test-data/
+branchName := main
+githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 .PHONY: test-data
 test-data:
 	rm -rf $(testDataDir)
-	mkdir -p $(testDataDir)
-	gsutil cp gs://sdk-test-data/rac-experiments-v3.json $(testDataDir)
-	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
+	mkdir -p $(tempDir)
+	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
+	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	rm -rf ${tempDir}
 
 test: test-data
 	go test ./...

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -48,7 +48,7 @@ func (ec *EppoClient) GetStringAssignment(subjectKey string, flagKey string, sub
 	return variation.stringValue, err
 }
 
-func (ec *EppoClient) GetJSONAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error) {
+func (ec *EppoClient) GetJSONStringAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error) {
 	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, StringType)
 	return variation.stringValue, err
 }

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -37,7 +37,7 @@ func Test_e2e(t *testing.T) {
 
 		for _, subject := range experiment.SubjectsWithAttributes {
 			switch experiment.ValueType {
-			case "bool":
+			case "boolean":
 				booleanAssignment, err := client.GetBoolAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
 				if err == nil {
 					assert.Nil(t, err)
@@ -70,7 +70,7 @@ func Test_e2e(t *testing.T) {
 
 		for _, subject := range experiment.Subjects {
 			switch experiment.ValueType {
-			case "bool":
+			case "boolean":
 				booleanAssignment, err := client.GetBoolAssignment(subject, expName, dictionary{})
 				if err == nil {
 					assert.Nil(t, err)
@@ -103,7 +103,7 @@ func Test_e2e(t *testing.T) {
 		}
 
 		switch experiment.ValueType {
-		case "bool":
+		case "boolean":
 			expectedAssignments := []bool{}
 			for _, assignment := range experiment.ExpectedAssignments {
 				expectedAssignments = append(expectedAssignments, assignment.boolValue)

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -30,58 +30,103 @@ func Test_e2e(t *testing.T) {
 	for _, experiment := range tstData {
 		expName := experiment.Experiment
 
-		assignments := []string{}
+		booleanAssignments := []bool{}
+		jsonAssignments := []string{}
 		numericAssignments := []float64{}
+		stringAssignments := []string{}
 
 		for _, subject := range experiment.SubjectsWithAttributes {
-			if experiment.ValueType == "numeric" {
+			switch experiment.ValueType {
+			case "bool":
+				booleanAssignment, err := client.GetBoolAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
+				if err == nil {
+					assert.Nil(t, err)
+				}
+
+				booleanAssignments = append(booleanAssignments, booleanAssignment)
+			case "numeric":
 				numericAssignment, err := client.GetNumericAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
 				if err == nil {
 					assert.Nil(t, err)
 				}
 
 				numericAssignments = append(numericAssignments, numericAssignment)
-			} else {
-				assignment, err := client.GetStringAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
-				if assignment != "" {
+			case "json":
+				jsonAssignment, err := client.GetJSONStringAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
+				if err == nil {
 					assert.Nil(t, err)
 				}
 
-				assignments = append(assignments, assignment)
+				jsonAssignments = append(jsonAssignments, jsonAssignment)
+			case "string":
+				stringAssignment, err := client.GetStringAssignment(subject.SubjectKey, expName, subject.SubjectAttributes)
+				if err == nil {
+					assert.Nil(t, err)
+				}
+
+				stringAssignments = append(stringAssignments, stringAssignment)
 			}
 		}
 
 		for _, subject := range experiment.Subjects {
-			if experiment.ValueType == "numeric" {
+			switch experiment.ValueType {
+			case "bool":
+				booleanAssignment, err := client.GetBoolAssignment(subject, expName, dictionary{})
+				if err == nil {
+					assert.Nil(t, err)
+				}
+
+				booleanAssignments = append(booleanAssignments, booleanAssignment)
+			case "json":
+				jsonAssignment, err := client.GetJSONStringAssignment(subject, expName, dictionary{})
+				if err == nil {
+					assert.Nil(t, err)
+				}
+
+				jsonAssignments = append(jsonAssignments, jsonAssignment)
+			case "numeric":
 				numericAssignment, err := client.GetNumericAssignment(subject, expName, dictionary{})
 				if err == nil {
 					assert.Nil(t, err)
 				}
 
 				numericAssignments = append(numericAssignments, numericAssignment)
-			} else {
-				assignment, err := client.GetStringAssignment(subject, expName, dictionary{})
+			case "string":
+				stringAssignment, err := client.GetStringAssignment(subject, expName, dictionary{})
 
-				if assignment != "" {
+				if err == nil {
 					assert.Nil(t, err)
 				}
 
-				assignments = append(assignments, assignment)
+				stringAssignments = append(stringAssignments, stringAssignment)
 			}
 		}
 
-		if experiment.ValueType == "numeric" {
+		switch experiment.ValueType {
+		case "bool":
+			expectedAssignments := []bool{}
+			for _, assignment := range experiment.ExpectedAssignments {
+				expectedAssignments = append(expectedAssignments, assignment.boolValue)
+			}
+			assert.Equal(t, expectedAssignments, booleanAssignments)
+		case "json":
+			expectedAssignments := []string{}
+			for _, assignment := range experiment.ExpectedAssignments {
+				expectedAssignments = append(expectedAssignments, assignment.stringValue)
+			}
+			assert.Equal(t, expectedAssignments, jsonAssignments)
+		case "numeric":
 			expectedAssignments := []float64{}
 			for _, assignment := range experiment.ExpectedAssignments {
 				expectedAssignments = append(expectedAssignments, assignment.numericValue)
 			}
 			assert.Equal(t, expectedAssignments, numericAssignments)
-		} else {
+		case "string":
 			expectedAssignments := []string{}
 			for _, assignment := range experiment.ExpectedAssignments {
 				expectedAssignments = append(expectedAssignments, assignment.stringValue)
 			}
-			assert.Equal(t, expectedAssignments, assignments)
+			assert.Equal(t, expectedAssignments, stringAssignments)
 		}
 	}
 }

--- a/eppoclient/value.go
+++ b/eppoclient/value.go
@@ -42,6 +42,7 @@ func (receiver *Value) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*receiver = castInterfaceToValue(valueInterface)
+
 	return nil
 }
 
@@ -64,6 +65,9 @@ func castInterfaceToValue(valueInterface interface{}) Value {
 			return Null()
 		}
 		return Bool(*v)
+	case map[string]interface{}:
+		out, _ := json.Marshal(&v)
+		return String(string(out))
 	case string:
 		return String(v)
 	case *string:


### PR DESCRIPTION
## motivation

Added new shared test cases and found json variation values were not being handled correctly; returning empty strings - https://linear.app/eppo/issue/FF-883/json-variant-type-not-being-handled-in-golang-sdk

renamed `getJSONAssignment` to `getJSONStringAssignment` inline with our changes across SDKs.

## description

through some debugging I discovered that golang was unmarshaling the string encoded json in the `typedValue` field into native golang objects. that means that the existing `switch` statement in `value.go` did not account for it and the default behavior of `Null()` was occurring.

while this is admirable native behavior for json, at this time we are not supporting it and desire to return string encoded json for consistency across SDKs.