### PR TITLE
Add marshaling and unmarshaling of Value struct (FF-1382)

### DIFF
--- a/eppoclient/assignmentlogger.go
+++ b/eppoclient/assignmentlogger.go
@@ -7,13 +7,13 @@ type IAssignmentLogger interface {
 }
 
 type AssignmentEvent struct {
-	Experiment        string
-	FeatureFlag       string
-	Allocation        string
-	Variation         Value
-	Subject           string
-	Timestamp         string
-	SubjectAttributes dictionary
+	Experiment        string     `json:"experiment"`
+	FeatureFlag       string     `json:"featureFlag"`
+	Allocation        string     `json:"allocation"`
+	Variation         Value      `json:"variation"`
+	Subject           string     `json:"subject"`
+	Timestamp         string     `json:"timestamp"`
+	SubjectAttributes dictionary `json:"subjectAttributes,omitempty"`
 }
 
 type AssignmentLogger struct {

--- a/eppoclient/assignmentlogger_test.go
+++ b/eppoclient/assignmentlogger_test.go
@@ -1,0 +1,62 @@
+package eppoclient
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestAssignmentEventSerialization tests the JSON serialization and deserialization of AssignmentEvent
+func TestAssignmentEventSerialization(t *testing.T) {
+	// Create a test case with each type
+	testCases := []AssignmentEvent{
+		{
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         Bool(true),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": String("testValue")},
+		},
+		{
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         Numeric(123.45),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": String("testValue")},
+		},
+		{
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         String("testVariation"),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": String("testValue")},
+		},
+		// todo: test JSON variation types.
+	}
+
+	for _, original := range testCases {
+		// Marshal to JSON
+		marshaled, err := json.Marshal(original)
+		if err != nil {
+			t.Errorf("Failed to marshal: %v", err)
+		}
+
+		// Unmarshal from JSON
+		var unmarshaled Value
+		err = json.Unmarshal(marshaled, &unmarshaled)
+		if err != nil {
+			t.Errorf("Failed to unmarshal: %v", err)
+		}
+
+		// Compare the original and unmarshaled
+		if !reflect.DeepEqual(original, unmarshaled) {
+			t.Errorf("Original and unmarshaled Value are not equal. Original: %+v, Unmarshaled: %+v", original, unmarshaled)
+		}
+	}
+}

--- a/eppoclient/assignmentlogger_test.go
+++ b/eppoclient/assignmentlogger_test.go
@@ -37,7 +37,15 @@ func TestAssignmentEventSerialization(t *testing.T) {
 			Timestamp:   "testTimestamp",
 			//SubjectAttributes: dictionary{"testKey": String("testValue")},
 		},
-		// todo: test JSON variation types.
+		{
+			Experiment:  "testExperiment",
+			FeatureFlag: "testFeatureFlag",
+			Allocation:  "testAllocation",
+			Variation:   String("{\"foo\":\"bar\",\"car\":\"far\"}"),
+			Subject:     "testSubject",
+			Timestamp:   "testTimestamp",
+			//SubjectAttributes: dictionary{"testKey": String("testValue")},
+		},
 	}
 
 	for _, original := range testCases {

--- a/eppoclient/assignmentlogger_test.go
+++ b/eppoclient/assignmentlogger_test.go
@@ -11,31 +11,31 @@ func TestAssignmentEventSerialization(t *testing.T) {
 	// Create a test case with each type
 	testCases := []AssignmentEvent{
 		{
-			Experiment:        "testExperiment",
-			FeatureFlag:       "testFeatureFlag",
-			Allocation:        "testAllocation",
-			Variation:         Bool(true),
-			Subject:           "testSubject",
-			Timestamp:         "testTimestamp",
-			SubjectAttributes: dictionary{"testKey": String("testValue")},
+			Experiment:  "testExperiment",
+			FeatureFlag: "testFeatureFlag",
+			Allocation:  "testAllocation",
+			Variation:   Bool(true),
+			Subject:     "testSubject",
+			Timestamp:   "testTimestamp",
+			// SubjectAttributes: dictionary{"testKey": String("testValue")},
 		},
 		{
-			Experiment:        "testExperiment",
-			FeatureFlag:       "testFeatureFlag",
-			Allocation:        "testAllocation",
-			Variation:         Numeric(123.45),
-			Subject:           "testSubject",
-			Timestamp:         "testTimestamp",
-			SubjectAttributes: dictionary{"testKey": String("testValue")},
+			Experiment:  "testExperiment",
+			FeatureFlag: "testFeatureFlag",
+			Allocation:  "testAllocation",
+			Variation:   Numeric(123.45),
+			Subject:     "testSubject",
+			Timestamp:   "testTimestamp",
+			//SubjectAttributes: dictionary{"testKey": String("testValue")},
 		},
 		{
-			Experiment:        "testExperiment",
-			FeatureFlag:       "testFeatureFlag",
-			Allocation:        "testAllocation",
-			Variation:         String("testVariation"),
-			Subject:           "testSubject",
-			Timestamp:         "testTimestamp",
-			SubjectAttributes: dictionary{"testKey": String("testValue")},
+			Experiment:  "testExperiment",
+			FeatureFlag: "testFeatureFlag",
+			Allocation:  "testAllocation",
+			Variation:   String("testVariation"),
+			Subject:     "testSubject",
+			Timestamp:   "testTimestamp",
+			//SubjectAttributes: dictionary{"testKey": String("testValue")},
 		},
 		// todo: test JSON variation types.
 	}
@@ -48,7 +48,7 @@ func TestAssignmentEventSerialization(t *testing.T) {
 		}
 
 		// Unmarshal from JSON
-		var unmarshaled Value
+		var unmarshaled AssignmentEvent
 		err = json.Unmarshal(marshaled, &unmarshaled)
 		if err != nil {
 			t.Errorf("Failed to unmarshal: %v", err)

--- a/eppoclient/assignmentlogger_test.go
+++ b/eppoclient/assignmentlogger_test.go
@@ -10,24 +10,7 @@ import (
 func TestAssignmentEventSerialization(t *testing.T) {
 	// Create a test case with each type
 	testCases := []AssignmentEvent{
-		{
-			Experiment:  "testExperiment",
-			FeatureFlag: "testFeatureFlag",
-			Allocation:  "testAllocation",
-			Variation:   Bool(true),
-			Subject:     "testSubject",
-			Timestamp:   "testTimestamp",
-			// SubjectAttributes: dictionary{"testKey": String("testValue")},
-		},
-		{
-			Experiment:  "testExperiment",
-			FeatureFlag: "testFeatureFlag",
-			Allocation:  "testAllocation",
-			Variation:   Numeric(123.45),
-			Subject:     "testSubject",
-			Timestamp:   "testTimestamp",
-			//SubjectAttributes: dictionary{"testKey": String("testValue")},
-		},
+		// empty subject attributes
 		{
 			Experiment:  "testExperiment",
 			FeatureFlag: "testFeatureFlag",
@@ -35,16 +18,42 @@ func TestAssignmentEventSerialization(t *testing.T) {
 			Variation:   String("testVariation"),
 			Subject:     "testSubject",
 			Timestamp:   "testTimestamp",
-			//SubjectAttributes: dictionary{"testKey": String("testValue")},
 		},
 		{
-			Experiment:  "testExperiment",
-			FeatureFlag: "testFeatureFlag",
-			Allocation:  "testAllocation",
-			Variation:   String("{\"foo\":\"bar\",\"car\":\"far\"}"),
-			Subject:     "testSubject",
-			Timestamp:   "testTimestamp",
-			//SubjectAttributes: dictionary{"testKey": String("testValue")},
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         Bool(true),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": "testValue"},
+		},
+		{
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         Numeric(123.45),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": "testValue"},
+		},
+		{
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         String("testVariation"),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": "testValue"},
+		},
+		{
+			Experiment:        "testExperiment",
+			FeatureFlag:       "testFeatureFlag",
+			Allocation:        "testAllocation",
+			Variation:         String("{\"foo\":\"bar\",\"car\":\"far\"}"),
+			Subject:           "testSubject",
+			Timestamp:         "testTimestamp",
+			SubjectAttributes: dictionary{"testKey": "testValue"},
 		},
 	}
 

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -35,22 +35,22 @@ func (ec *EppoClient) GetAssignment(subjectKey string, flagKey string, subjectAt
 
 func (ec *EppoClient) GetBoolAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (bool, error) {
 	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, BoolType)
-	return variation.boolValue, err
+	return variation.BoolValue, err
 }
 
 func (ec *EppoClient) GetNumericAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (float64, error) {
 	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, NumericType)
-	return variation.numericValue, err
+	return variation.NumericValue, err
 }
 
 func (ec *EppoClient) GetStringAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error) {
 	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, StringType)
-	return variation.stringValue, err
+	return variation.StringValue, err
 }
 
 func (ec *EppoClient) GetJSONStringAssignment(subjectKey string, flagKey string, subjectAttributes dictionary) (string, error) {
 	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, StringType)
-	return variation.stringValue, err
+	return variation.StringValue, err
 }
 
 func (ec *EppoClient) getAssignment(subjectKey string, flagKey string, subjectAttributes dictionary, valueType ValueType) (Value, error) {

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -232,20 +232,20 @@ func Test_WithSubjectInOverrides(t *testing.T) {
 			case StringType:
 				assignment, _ := client.GetStringAssignment("user-1", "experiment-key-1", dictionary{})
 
-				if assignment != tt.want.stringValue {
-					t.Errorf("got %s, want %s", assignment, tt.want.stringValue)
+				if assignment != tt.want.StringValue {
+					t.Errorf("got %s, want %s", assignment, tt.want.StringValue)
 				}
 			case NumericType:
 				assignment, _ := client.GetNumericAssignment("user-1", "experiment-key-1", dictionary{})
 
-				if assignment != tt.want.numericValue {
-					t.Errorf("got %T, want %T", assignment, tt.want.numericValue)
+				if assignment != tt.want.NumericValue {
+					t.Errorf("got %T, want %T", assignment, tt.want.NumericValue)
 				}
 			case BoolType:
 				assignment, _ := client.GetBoolAssignment("user-1", "experiment-key-1", dictionary{})
 
-				if assignment != tt.want.boolValue {
-					t.Errorf("got %t, want %t", assignment, tt.want.boolValue)
+				if assignment != tt.want.BoolValue {
+					t.Errorf("got %t, want %t", assignment, tt.want.BoolValue)
 				}
 
 			}

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -106,25 +106,25 @@ func Test_e2e(t *testing.T) {
 		case "boolean":
 			expectedAssignments := []bool{}
 			for _, assignment := range experiment.ExpectedAssignments {
-				expectedAssignments = append(expectedAssignments, assignment.boolValue)
+				expectedAssignments = append(expectedAssignments, assignment.BoolValue)
 			}
 			assert.Equal(t, expectedAssignments, booleanAssignments)
 		case "json":
 			expectedAssignments := []string{}
 			for _, assignment := range experiment.ExpectedAssignments {
-				expectedAssignments = append(expectedAssignments, assignment.stringValue)
+				expectedAssignments = append(expectedAssignments, assignment.StringValue)
 			}
 			assert.Equal(t, expectedAssignments, jsonAssignments)
 		case "numeric":
 			expectedAssignments := []float64{}
 			for _, assignment := range experiment.ExpectedAssignments {
-				expectedAssignments = append(expectedAssignments, assignment.numericValue)
+				expectedAssignments = append(expectedAssignments, assignment.NumericValue)
 			}
 			assert.Equal(t, expectedAssignments, numericAssignments)
 		case "string":
 			expectedAssignments := []string{}
 			for _, assignment := range experiment.ExpectedAssignments {
-				expectedAssignments = append(expectedAssignments, assignment.stringValue)
+				expectedAssignments = append(expectedAssignments, assignment.StringValue)
 			}
 			assert.Equal(t, expectedAssignments, stringAssignments)
 		}

--- a/eppoclient/value.go
+++ b/eppoclient/value.go
@@ -103,7 +103,10 @@ func (v *Value) UnmarshalJSON(data []byte) error {
 		}
 		*v = Bool(*value)
 	case map[string]interface{}:
-		out, _ := json.Marshal(typedValue)
+		out, err := json.Marshal(typedValue)
+		if err != nil {
+			return err
+		}
 		*v = String(string(out))
 	case nil:
 		*v = Null()


### PR DESCRIPTION
## motivation

Enable serialization of `AssignmentEvent` struct which is blocked on being unable to unmarshal the `Value` struct as this handler does not exist.

https://linear.app/eppo/issue/FF-1382/add-serialization-to-go-iassignmentlogger

## description

Adds support for marshalling and unmarshalling the `Value` struct.

**known deficiencies**

`SubjectAttributes` is being marshaled to a string in all cases; need to convert this to a `map[string]Value` to preserve type.