### PR TITLE
Use mock assignment logger and verify it is being called (FF-1450)

### DIFF
--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -20,19 +20,12 @@ const MOCK_RAC_RESPONSE_FILE = "test-data/rac-experiments-v3.json"
 
 var tstData = []testData{}
 
-type MyTestAssignmentLogger struct {
-	mock.Mock
-}
-
-func (o *MyTestAssignmentLogger) LogAssignment(event AssignmentEvent) {
-	o.Called(event)
-}
-
 func Test_e2e(t *testing.T) {
 	serverUrl := initFixture()
 
-	mockAssignmentLogger := &MyTestAssignmentLogger{}
-	client := InitClient(Config{BaseUrl: serverUrl, ApiKey: "dummy", AssignmentLogger: mockAssignmentLogger})
+	mockLogger := new(mockLogger)
+	mockLogger.Mock.On("LogAssignment", mock.Anything).Return()
+	client := InitClient(Config{BaseUrl: serverUrl, ApiKey: "dummy", AssignmentLogger: mockLogger})
 
 	time.Sleep(2 * time.Second)
 
@@ -138,7 +131,7 @@ func Test_e2e(t *testing.T) {
 			assert.Equal(t, expectedAssignments, stringAssignments)
 		}
 
-		mockAssignmentLogger.AssertCalled(t, "LogAssignment", mock.Anything)
+		mockLogger.AssertCalled(t, "LogAssignment", mock.Anything)
 	}
 }
 

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const TEST_DATA_DIR = "test-data/assignment-v2"
@@ -19,11 +20,19 @@ const MOCK_RAC_RESPONSE_FILE = "test-data/rac-experiments-v3.json"
 
 var tstData = []testData{}
 
+type MyTestAssignmentLogger struct {
+	mock.Mock
+}
+
+func (o *MyTestAssignmentLogger) LogAssignment(event AssignmentEvent) {
+	o.Called(event)
+}
+
 func Test_e2e(t *testing.T) {
 	serverUrl := initFixture()
 
-	asmntLogger := &AssignmentLogger{}
-	client := InitClient(Config{BaseUrl: serverUrl, ApiKey: "dummy", AssignmentLogger: asmntLogger})
+	mockAssignmentLogger := &MyTestAssignmentLogger{}
+	client := InitClient(Config{BaseUrl: serverUrl, ApiKey: "dummy", AssignmentLogger: mockAssignmentLogger})
 
 	time.Sleep(2 * time.Second)
 
@@ -128,6 +137,8 @@ func Test_e2e(t *testing.T) {
 			}
 			assert.Equal(t, expectedAssignments, stringAssignments)
 		}
+
+		mockAssignmentLogger.AssertCalled(t, "LogAssignment", mock.Anything)
 	}
 }
 

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -15,7 +15,7 @@ func InitClient(config Config) *EppoClient {
 	httpClient := newHttpClient(config.BaseUrl, &http.Client{Timeout: REQUEST_TIMEOUT_SECONDS}, sdkParams)
 	configStore := newConfigurationStore(MAX_CACHE_ENTRIES)
 	requestor := newExperimentConfigurationRequestor(*httpClient, configStore)
-	assignmentLogger := NewAssignmentLogger()
+	assignmentLogger := config.AssignmentLogger
 
 	client := newEppoClient(requestor, assignmentLogger)
 


### PR DESCRIPTION
## added unit test to verify issue

```
--- FAIL: Test_e2e (2.06s)
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
    /Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141: 
        	Error Trace:	/Users/leo/src/golang-sdk/eppoclient/eppoclient_e2e_test.go:141
        	Error:      	Should have called with given arguments
        	Test:       	Test_e2e
        	Messages:   	Expected "LogAssignment" to have been called with:
        	            	[mock.Anything]
        	            	but no actual calls happened
FAIL
FAIL	github.com/Eppo-exp/golang-sdk/v2/eppoclient	2.364s
FAIL
```

## resolution

Use passed logger from `Config` object.