### PR TITLE
avoid extra json marshal when loading configuration from cache (FF-1564)

### DIFF
--- a/.github/workflows/memory-profile-compare.yml
+++ b/.github/workflows/memory-profile-compare.yml
@@ -54,9 +54,15 @@ jobs:
         name: memprofile-main
         path: .
     
-    - name: Compare memory profiles
-      run: make profile-memory-compare BASE_FILE=memprofile.main.out COMPARE_FILE=memprofile.feat.out > memory-profile-comparison.text
+    - name: Display structure of downloaded files
+      run: ls -R
     
+    - name: Compare memory profiles
+      run: make profile-memory-compare BASE_FILE=memprofile.main.out FEAT_FILE=memprofile.feat.out > memory-profile-comparison.text
+    
+    - name: Show memory profile comparison
+      run: cat memory-profile-comparison.text
+
     - name: Upload comparison result
       uses: actions/upload-artifact@v2
       with:

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -3,7 +3,6 @@ package eppoclient
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -103,23 +102,6 @@ func (ec *EppoClient) getAssignment(subjectKey string, flagKey string, subjectAt
 
 	assignedVariation := variationShard.Value
 
-	// Log assignment
-	assignmentEvent := AssignmentEvent{
-		Experiment:        flagKey + "-" + rule.AllocationKey,
-		FeatureFlag:       flagKey,
-		Allocation:        rule.AllocationKey,
-		Variation:         assignedVariation,
-		Subject:           subjectKey,
-		Timestamp:         time.Now().String(),
-		SubjectAttributes: subjectAttributes,
-	}
-
-	_, jsonErr := json.Marshal(assignmentEvent)
-
-	if jsonErr != nil {
-		panic("incorrect json")
-	}
-
 	func() {
 		// need to catch panics from Logger and continue
 		defer func() {
@@ -129,6 +111,16 @@ func (ec *EppoClient) getAssignment(subjectKey string, flagKey string, subjectAt
 			}
 		}()
 
+		// Log assignment
+		assignmentEvent := AssignmentEvent{
+			Experiment:        flagKey + "-" + rule.AllocationKey,
+			FeatureFlag:       flagKey,
+			Allocation:        rule.AllocationKey,
+			Variation:         assignedVariation,
+			Subject:           subjectKey,
+			Timestamp:         time.Now().String(),
+			SubjectAttributes: subjectAttributes,
+		}
 		ec.logger.LogAssignment(assignmentEvent)
 	}()
 

--- a/eppoclient/configurationrequestor.go
+++ b/eppoclient/configurationrequestor.go
@@ -7,6 +7,10 @@ import (
 
 const RAC_ENDPOINT = "/randomized_assignment/v3/config"
 
+type racResponse struct {
+	Flags map[string]experimentConfiguration `json:"flags"`
+}
+
 type iConfigRequestor interface {
 	GetConfiguration(key string) (experimentConfiguration, error)
 	FetchAndStoreConfigurations()
@@ -36,24 +40,21 @@ func (ecr *experimentConfigurationRequestor) GetConfiguration(experimentKey stri
 }
 
 func (ecr *experimentConfigurationRequestor) FetchAndStoreConfigurations() {
-	var responseBody map[string]json.RawMessage
-
-	configs := dictionary{}
 	result := ecr.httpClient.get(RAC_ENDPOINT)
+	var wrapper racResponse
 
-	err := json.Unmarshal([]byte(result), &responseBody)
-
+	// Unmarshal JSON data directly into the wrapper struct
+	err := json.Unmarshal([]byte(result), &wrapper)
 	if err != nil {
-		fmt.Println("Failed to unmarshal RAC response json", result)
+		fmt.Println("Failed to unmarshal RAC response JSON", result)
 		fmt.Println(err)
+		return
 	}
 
-	err = json.Unmarshal(responseBody["flags"], &configs)
-
+	// Now wrapper.Flags contains all configurations mapped by their keys
+	// Pass this map directly to SetConfigurations
+	err = ecr.configStore.SetConfigurations(wrapper.Flags)
 	if err != nil {
-		fmt.Println("Failed to unmarshal RAC response json in experiments section", result)
-		fmt.Println(err)
+		fmt.Println("Failed to set configurations in cache", err)
 	}
-
-	ecr.configStore.SetConfigurations(configs)
 }

--- a/eppoclient/configurationstore_test.go
+++ b/eppoclient/configurationstore_test.go
@@ -21,38 +21,55 @@ const TEST_MAX_SIZE = 10
 
 func Test_GetConfiguration_unknownKey(t *testing.T) {
 	var store = newConfigurationStore(TEST_MAX_SIZE)
-	store.SetConfigurations(dictionary{"randomization_algo": testExp})
-	_, err := store.GetConfiguration("unknown_exp")
+	err := store.SetConfigurations(map[string]experimentConfiguration{
+		"randomization_algo": testExp,
+	})
+
+	assert.NoError(t, err)
+	result, err := store.GetConfiguration("unknown_exp")
 
 	assert.Error(t, err)
+	assert.Equal(t, experimentConfiguration{}, result)
 }
 
 func Test_GetConfiguration_knownKey(t *testing.T) {
 	var store = newConfigurationStore(TEST_MAX_SIZE)
-	store.SetConfigurations(dictionary{"randomization_algo": testExp})
-	result, _ := store.GetConfiguration("randomization_algo")
+	err := store.SetConfigurations(map[string]experimentConfiguration{
+		"randomization_algo": testExp,
+	})
+	assert.NoError(t, err)
+	result, err := store.GetConfiguration("randomization_algo")
 
 	expected := "randomization_algo"
 
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result.Name)
 }
 
 func Test_GetConfiguration_evictsOldEntriesWhenMaxSizeExceeded(t *testing.T) {
 	var store = newConfigurationStore(TEST_MAX_SIZE)
-	store.SetConfigurations(dictionary{"item_to_be_evicted": testExp})
-	result, _ := store.GetConfiguration("item_to_be_evicted")
+	err := store.SetConfigurations(map[string]experimentConfiguration{
+		"item_to_be_evicted": testExp,
+	})
+	assert.NoError(t, err)
+	result, err := store.GetConfiguration("item_to_be_evicted")
 
 	expected := "randomization_algo"
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result.Name)
 
 	for i := 0; i < TEST_MAX_SIZE; i++ {
 		dictKey := fmt.Sprintf("test-entry-%v", i)
-		store.SetConfigurations(dictionary{dictKey: testExp})
+		err := store.SetConfigurations(map[string]experimentConfiguration{
+			dictKey: testExp,
+		})
+		assert.NoError(t, err)
 	}
 
-	result, err := store.GetConfiguration("item_to_be_evicted")
+	result, err = store.GetConfiguration("item_to_be_evicted")
 	assert.Error(t, err)
 
-	result, _ = store.GetConfiguration(fmt.Sprintf("test-entry-%v", TEST_MAX_SIZE-1))
+	result, err = store.GetConfiguration(fmt.Sprintf("test-entry-%v", TEST_MAX_SIZE-1))
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result.Name)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Eppo-exp/golang-sdk/v2
 go 1.19
 
 require (
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/stretchr/testify v1.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=


### PR DESCRIPTION
## context

Eppo downloads configuration files from its RAC API at regular intervals; this data is cached in local memory.

When serving evaluations they are loaded from the cache.

## problem

* When serving evaluations the `GetConfiguration` is performing a redundant `json.Marshall` to convert the stored cache entry into a json string. this allocates memory without meaningful utility.
* The `getAssignment` method performed redundant `json.Marshall` on the assignment logging object.

Overall the "read path" of the SDK was allocating substantial number of objects without obvious value.

## changes

Optimizes the "read path" to trust the cached entry and instantiate the `experimentConfiguration` object directly. Shifts json validation to the "write path" which happens in the background and much less frequently, outside of the main execution thread.

_memory savings in the read path_

1. `getAssignment` - removes a redundant `json.Marshal` when creating the assignment logging event
2.  `GetConfiguration` - removes a redundant `json.Marshal` when loading object from cache; removes a `json.Unmarshall`

_memory savings in write path_

`FetchAndStoreConfigurations` - remove extra `json.Unmarshal`

**other quality of life changes**

It is standard in golang to return an `error` with each function call; instead of a log message I am doing this at each method with the most context of the issue. the caller can choose to handle it.

Updated the `lru.cache` library to `v2` which includes support for generics. Instantiated the object with `[string, experimentConfiguration]` for clear type safety. This avoids passing around `dictionary` and `interface{}` objects which is what led to all the json serialization.

## demonstrating lower memory allocation

This profile comparison file is ready from the github action attached to this PR:

Here we see all the removed allocations, namely a 19.10MB reduction in `GetStringAssignment` 

```
go tool pprof -base $BASE_FILE -text $FEAT_FILE
File: eppoclient.test
Type: alloc_space
Time: Feb 15, 2024 at 12:40am (UTC)
Showing nodes accounting for -19.6[7](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:8)MB, 32.44% of 60.63MB total
Dropped [8](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:9) nodes (cum <= 0.30MB)
      flat  flat%   sum%        cum   cum%
   -6.50MB 10.72% 10.72%   -11.50MB 18.[9](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:10)7%  encoding/json.mapEncoder.encode
    4.50MB  5.77%  4.95%     2.50MB  4.12%  github.com/stretchr/testify/assert.CallerInfo
      -3MB  4.95%  9.90%       -3MB  4.95%  internal/reflectlite.Swapper
   -2.50MB  4.13% 14.02%      -14MB 23.09%  encoding/json.Marshal
      -2MB  3.30% 17.32%    -3.46MB  5.70%  encoding/json.Unmarshal
      -2MB  3.30% 20.62%       -2MB  3.30%  reflect.copyVal
   -1.50MB  2.47% 23.[10](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:11)%    -1.50MB  2.47%  reflect.mapassign_faststr
   -1.50MB  2.47% 25.57%    -1.50MB  2.47%  os.statNolog
   -1.16MB  1.91% 27.48%    -1.16MB  1.91%  github.com/stretchr/testify/mock.(*Mock).calls (inline)
       1MB  1.65% 25.83%        1MB  1.65%  fmt.Sprintf
      -1MB  1.65% 27.48%   -19.10MB 31.50%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*EppoClient).getAssignment
   -0.58MB  0.96% 28.44%     2.42MB  3.99%  github.com/stretchr/testify/mock.(*Mock).MethodCalled
    0.55MB   0.9% 27.54%     0.55MB   0.9%  reflect.unsafe_NewArray
    0.53MB  0.88% 26.66%     0.53MB  0.88%  net.open
   -0.52MB  0.85% 27.51%    -0.52MB  0.85%  regexp.(*bitState).reset
   -0.51MB  0.84% 28.35%   -19.67MB 32.44%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.Test_e2e
    0.50MB  0.82% 27.52%     0.50MB  0.82%  regexp/syntax.(*compiler).inst (inline)
   -0.50MB  0.82% 28.35%       -1MB  1.65%  regexp.compile
   -0.50MB  0.82% 29.17%       -1MB  1.65%  regexp/syntax.parse
   -0.50MB  0.82% 30.00%    -0.50MB  0.82%  regexp/syntax.(*parser).newRegexp (inline)
    0.50MB  0.82% 29.17%     0.50MB  0.82%  net/http.(*persistConn).readLoop
   -0.50MB  0.82% 30.00%    -0.50MB  0.82%  net/textproto.(*Reader).ReadLine (inline)
   -0.50MB  0.82% 30.82%    -0.50MB  0.82%  runtime.main
   -0.50MB  0.82% 31.65%    -1.50MB  2.47%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*Value).UnmarshalJSON
   -0.50MB  0.82% 32.47%   -18.50MB 30.52%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*configurationStore).GetConfiguration
    0.50MB  0.82% 31.65%     0.50MB  0.82%  net/http.(*Server).Serve
   -0.48MB  0.79% 32.44%    -0.48MB  0.79%  io.ReadAll
         0     0% 32.44%    -0.95MB  1.57%  encoding/json.(*decodeState).array
         0     0% 32.44%    -1.50MB  2.47%  encoding/json.(*decodeState).literalStore
         0     0% 32.44%    -2.46MB  4.05%  encoding/json.(*decodeState).object
         0     0% 32.44%    -2.46MB  4.05%  encoding/json.(*decodeState).unmarshal
         0     0% 32.44%    -2.46MB  4.05%  encoding/json.(*decodeState).value
         0     0% 32.44%   -[11](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:12).50MB 18.97%  encoding/json.(*encodeState).marshal
         0     0% 32.44%   -11.50MB 18.97%  encoding/json.(*encodeState).reflectValue
         0     0% 32.44%    -7.50MB [12](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:13).37%  encoding/json.arrayEncoder.encode
         0     0% 32.44%       -9MB [14](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:15).84%  encoding/json.interfaceEncoder
         0     0% 32.44%    -7.50MB 12.37%  encoding/json.sliceEncoder.encode
         0     0% 32.44%   -19.10MB 31.50%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*EppoClient).GetStringAssignment (inline)
         0     0% 32.44%     0.90MB  1.49%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*EppoClient).getAssignment.func1
         0     0% 32.44%   -18.50MB 30.52%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*experimentConfigurationRequestor).GetConfiguration
         0     0% 32.44%     0.90MB  1.49%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.(*mockLogger).LogAssignment
         0     0% 32.44%     0.57MB  0.93%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.getTestData
         0     0% 32.44%     1.10MB  1.81%  github.com/Eppo-exp/golang-sdk/v2/eppoclient.initFixture
         0     0% 32.44%    -1.[16](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:17)MB  1.91%  github.com/stretchr/testify/mock.(*Mock).AssertCalled
         0     0% 32.44%     0.90MB  1.49%  github.com/stretchr/testify/mock.(*Mock).Called
         0     0% 32.44%     0.50MB  0.82%  github.com/stretchr/testify/mock.(*Mock).findExpectedCall
         0     0% 32.44%    -1.16MB  1.91%  github.com/stretchr/testify/mock.(*Mock).methodWasCalled
         0     0% 32.44%     0.50MB  0.82%  github.com/stretchr/testify/mock.Arguments.Diff
         0     0% 32.44%     0.53MB  0.88%  net.(*ListenConfig).Listen
         0     0% 32.44%     0.53MB  0.88%  net.(*sysListener).listenTCP
         0     0% 32.44%     0.53MB  0.88%  net.Listen
         0     0% 32.44%     0.53MB  0.88%  net.internetSocket
         0     0% 32.44%     0.53MB  0.88%  net.listenerBacklog
         0     0% 32.44%     0.53MB  0.88%  net.listenerBacklog.func1
         0     0% 32.44%     0.53MB  0.88%  net.maxListenerBacklog
         0     0% 32.44%     0.53MB  0.88%  net.socket
         0     0% 32.44%    -0.50MB  0.82%  net/http.(*conn).readRequest
         0     0% 32.44%    -0.50MB  0.82%  net/http.(*conn).serve
         0     0% 32.44%    -0.50MB  0.82%  net/http.readRequest
         0     0% 32.44%     0.50MB  0.82%  net/http/httptest.(*Server).goServe.func1
         0     0% 32.44%     0.53MB  0.88%  net/http/httptest.NewServer
         0     0% 32.44%     0.53MB  0.88%  net/http/httptest.NewUnstartedServer (inline)
         0     0% 32.44%     0.53MB  0.88%  net/http/httptest.newLocalListener
         0     0% 32.44%    -1.50MB  2.47%  os.Getwd
         0     0% 32.44%    -1.50MB  2.47%  path/filepath.Abs
         0     0% 32.44%    -1.50MB  2.47%  path/filepath.abs (inline)
         0     0% 32.44%    -1.50MB  2.47%  path/filepath.unixAbs
         0     0% 32.44%       -1MB  1.65%  reflect.(*MapIter).Key
         0     0% 32.44%       -1MB  1.65%  reflect.(*MapIter).Value
         0     0% 32.44%     0.55MB   0.9%  reflect.MakeSlice
         0     0% 32.44%    -1.50MB  2.47%  reflect.Value.SetMapIndex
         0     0% 32.44%    -0.52MB  0.85%  regexp.(*Regexp).MatchString (inline)
         0     0% 32.44%    -0.52MB  0.85%  regexp.(*Regexp).backtrack
         0     0% 32.44%    -0.52MB  0.85%  regexp.(*Regexp).doExecute
         0     0% 32.44%    -0.52MB  0.85%  regexp.(*Regexp).doMatch (inline)
         0     0% 32.44%       -1MB  1.65%  regexp.Compile (inline)
         0     0% 32.44%       -1MB  1.65%  regexp.MustCompile
         0     0% 32.44%     0.50MB  0.82%  regexp/syntax.(*compiler).compile
         0     0% 32.44%     0.50MB  0.82%  regexp/syntax.(*compiler).rune
         0     0% 32.44%    -0.50MB  0.82%  regexp/syntax.(*parser).literal
         0     0% 32.44%     0.50MB  0.82%  regexp/syntax.Compile
         0     0% 32.44%       -1MB  1.65%  regexp/syntax.Parse (inline)
         0     0% 32.44%       -3MB  4.95%  sort.Slice
         0     0% 32.44%     0.53MB  0.88%  sync.(*Once).Do (inline)
         0     0% 32.44%     0.53MB  0.88%  sync.(*Once).doSlow
         0     0% 32.44%   -[19](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:20).67MB [32](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:33).[44](https://github.com/Eppo-exp/golang-sdk/actions/runs/7909366588/job/21590268816?pr=31#step:13:45)%  testing.tRunner
```