### PR TITLE
add stub makefile commands for memory profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,12 @@ test: test-data
 
 lint:
 	golangci-lint run
+
+## profile-memory - Run test and generate memory profile
+profile-memory:
+	echo "Run test and generate memory profile"
+
+## profile-memory-compare - Compare two memory profiles
+## example: make profile-memory-compare BASE_FILE=memprofile1.out FEAT_FILE=memprofile2.out
+profile-memory-compare:
+	echo "Compare two memory profiles"


### PR DESCRIPTION
I am adding a benching suite that will generate a memory profile against main branch and compare it with the feature branch. https://github.com/Eppo-exp/golang-sdk/pull/32

However I am currently blocked as the main branch does not have these two commands and is failing to run.

👉 Adding here to unblock.