### PR TITLE
allow subject attributes to be string wrapper numerics; attempt to safely coerce

### DIFF
--- a/eppoclient/rules.go
+++ b/eppoclient/rules.go
@@ -62,9 +62,9 @@ func evaluateCondition(subjectAttributes dictionary, condition condition) bool {
 		return isNotOneOf(subjectValue, convertToStringArray(condition.Value))
 	default:
 		// Attempt to evaluate as numeric condition if both values are numeric.
-		subjectValueNumeric, isNumericSubject := subjectValue.(float64)        // Assuming float64 for general numeric comparison; adjust as needed.
-		conditionValueNumeric, isNumericCondition := condition.Value.(float64) // Same assumption as above.
-		if isNumericSubject && isNumericCondition {
+		subjectValueNumeric, isNumericSubjectErr := ToFloat64(subjectValue)
+		conditionValueNumeric, isNumericConditionErr := ToFloat64(condition.Value)
+		if isNumericSubjectErr == nil && isNumericConditionErr == nil {
 			return evaluateNumericCondition(subjectValueNumeric, conditionValueNumeric, condition)
 		}
 

--- a/eppoclient/rules.go
+++ b/eppoclient/rules.go
@@ -61,7 +61,7 @@ func evaluateCondition(subjectAttributes dictionary, condition condition) bool {
 	case "NOT_ONE_OF":
 		return isNotOneOf(subjectValue, convertToStringArray(condition.Value))
 	default:
-		// Attempt to evaluate as numeric condition if both values are numeric.
+		// Attempt to coerce both values to float64 and compare them.
 		subjectValueNumeric, isNumericSubjectErr := ToFloat64(subjectValue)
 		conditionValueNumeric, isNumericConditionErr := ToFloat64(condition.Value)
 		if isNumericSubjectErr == nil && isNumericConditionErr == nil {

--- a/eppoclient/rules_test.go
+++ b/eppoclient/rules_test.go
@@ -41,11 +41,22 @@ func Test_findMatchingRule_whenNoRulesMatch(t *testing.T) {
 }
 
 func Test_findMatchingRule_Success(t *testing.T) {
+	// Test with a numeric value
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 99.0
 
-	result, _ := findMatchingRule(subjectAttributes, []rule{numericRule})
+	result, err := findMatchingRule(subjectAttributes, []rule{numericRule})
 
+	assert.NoError(t, err)
+	assert.Equal(t, numericRule, result)
+
+	// Test with a string value
+	subjectAttributes = make(dictionary)
+	subjectAttributes["age"] = "99.0"
+
+	result, err = findMatchingRule(subjectAttributes, []rule{numericRule})
+
+	assert.NoError(t, err)
 	assert.Equal(t, numericRule, result)
 }
 

--- a/eppoclient/rules_test.go
+++ b/eppoclient/rules_test.go
@@ -41,6 +41,8 @@ func Test_findMatchingRule_whenNoRulesMatch(t *testing.T) {
 }
 
 func Test_findMatchingRule_Success(t *testing.T) {
+	// both numeric and string wrapped numeric attributes must match.
+
 	// Test with a numeric value
 	subjectAttributes := make(dictionary)
 	subjectAttributes["age"] = 99.0

--- a/eppoclient/utils.go
+++ b/eppoclient/utils.go
@@ -1,5 +1,11 @@
 package eppoclient
 
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
 type dictionary map[string]interface{}
 
 type testData struct {
@@ -25,4 +31,22 @@ type testDataVariations struct {
 type testDataShardRange struct {
 	Start int `json:"start"`
 	End   int `json:"end"`
+}
+
+// ToFloat64 attempts to convert an interface{} value to a float64.
+// It supports inputs of type float64 or string (which can be parsed as float64).
+// Returns a float64 and nil error on success, or 0 and an error on failure.
+func ToFloat64(val interface{}) (float64, error) {
+	switch v := val.(type) {
+	case float64:
+		return v, nil
+	case string:
+		floatVal, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot convert string '%s' to float64: %w", v, err)
+		}
+		return floatVal, nil
+	default:
+		return 0, errors.New("value is neither a float64 nor a convertible string")
+	}
 }

--- a/eppoclient/utils_test.go
+++ b/eppoclient/utils_test.go
@@ -1,0 +1,34 @@
+package eppoclient
+
+import (
+	"testing"
+)
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     interface{}
+		expected  float64
+		expectErr bool
+	}{
+		{"Float64Input", 123.456, 123.456, false},
+		{"StringInputValid", "789.012", 789.012, false},
+		{"StringInputInvalid", "abc", 0, true},
+		{"SemVerInputInvalid", "1.2.3", 0, true},
+		{"BoolInput", true, 0, true},
+		{"IntInput", 123, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToFloat64(tt.input)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("ToFloat64(%v) error = %v, expectErr %v", tt.input, err, tt.expectErr)
+				return
+			}
+			if !tt.expectErr && result != tt.expected {
+				t.Errorf("ToFloat64(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## context

A behavioral regression took place when creating semver support (https://github.com/Eppo-exp/golang-sdk/commit/5f8765036dafb7927204f204d862ac6f31d8b7f2) wherein subject attribute values in the format `"2"` stopped being coerced into numerics. This led to user confusion as evaluations stopped happening which they depended on.

## updated behavior

Both `2` and `"2"` will be treated as numerics (specifically `float64`) for the purposes of comparison evaluation.

The `ToFloat64` function is able to safely handle a variety of input values and return a converted value or an error that the caller much check against.

## testing

* new unit tests for `ToFloat64` function
* augmented unit tests for rule evaluation including both numeric and string wrapped numerics