### PR TITLE
Assignment timestamp in RFC 3339 format. (FF-2082)

### DIFF
--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"time"
 )
 
 // Client for eppo.cloud. Instance of this struct will be created on calling InitClient.
@@ -118,7 +117,7 @@ func (ec *EppoClient) getAssignment(subjectKey string, flagKey string, subjectAt
 			Allocation:        rule.AllocationKey,
 			Variation:         assignedVariation,
 			Subject:           subjectKey,
-			Timestamp:         time.Now().String(),
+			Timestamp:         TimeNow(),
 			SubjectAttributes: subjectAttributes,
 		}
 		ec.logger.LogAssignment(assignmentEvent)

--- a/eppoclient/utils.go
+++ b/eppoclient/utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 )
 
 type dictionary map[string]interface{}
@@ -49,4 +50,8 @@ func ToFloat64(val interface{}) (float64, error) {
 	default:
 		return 0, errors.New("value is neither a float64 nor a convertible string")
 	}
+}
+
+func TimeNow() string {
+	return time.Now().UTC().Format(time.RFC3339)
 }

--- a/eppoclient/utils_test.go
+++ b/eppoclient/utils_test.go
@@ -2,6 +2,7 @@ package eppoclient
 
 import (
 	"testing"
+	"time"
 )
 
 func TestToFloat64(t *testing.T) {
@@ -30,5 +31,13 @@ func TestToFloat64(t *testing.T) {
 				t.Errorf("ToFloat64(%v) = %v, want %v", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestTimeNow(t *testing.T) {
+	result := TimeNow()
+	_, err := time.Parse(time.RFC3339, result)
+	if err != nil {
+		t.Errorf("TimeNow() = %v, want %v", result, "")
 	}
 }


### PR DESCRIPTION
## observations

[eppo's documentation](https://docs.geteppo.com/sdks/server-sdks/go/#define-an-assignment-logger-experiment-assignment-only) shows an ISO 8601 date.

the assignment logger provides a timestamp as `2024-05-14 14:56:25.105294 -0700 PDT m=+10.002113084` which does not directly match.

## changes

Provide a timestamp in RFC 3339 format.

<img width="746" alt="Screenshot 2024-05-14 at 4 29 18 PM" src="https://github.com/Eppo-exp/golang-sdk/assets/57361/36e0b7b8-4665-4bcb-8083-e9be8598379f">