### PR TITLE
[ufc] update "get_assignment" args ordering to comply with ufc spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ In your `go.mod`, add the SDK package as a dependency:
 
 ```
 require (
-    github.com/Eppo-exp/golang-sdk/v3
+    github.com/Eppo-exp/golang-sdk/v4
 )
 ```
 
 Or you can install the SDK from the command line with:
 
 ```
-go get github.com/Eppo-exp/golang-sdk/v3
+go get github.com/Eppo-exp/golang-sdk/v4
 ```
 
 ## Quick start
@@ -40,7 +40,7 @@ Begin by initializing a singleton instance of Eppo's client. Once initialized, t
 
 ```go
 import (
-    "github.com/Eppo-exp/golang-sdk/v3/eppoclient"
+    "github.com/Eppo-exp/golang-sdk/v4/eppoclient"
 )
 
 var eppoClient = &eppoclient.EppoClient{}
@@ -60,16 +60,16 @@ func main() {
 
 ```go
 import (
-    "github.com/Eppo-exp/golang-sdk/v3/eppoclient"
+    "github.com/Eppo-exp/golang-sdk/v4/eppoclient"
 )
 
 var eppoClient = &eppoclient.EppoClient{}
 
 variation := eppoClient.GetStringAssignment(
+   "new-user-onboarding",
    user.id,
-   'new-user-onboarding',
    user.attributes,
-   'control'
+   "control"
 );
 ```
 
@@ -89,8 +89,8 @@ Each function has the same signature, but returns the type in the function name.
 
 ```go
 func getBooleanAssignment(
-	subjectKey string,
 	flagKey string,
+	subjectKey string,
 	subjectAttributes SubjectAttributes,
 	defaultValue string
 ) bool
@@ -105,7 +105,7 @@ The code below illustrates an example implementation of a logging callback using
 
 ```go
 import (
-  "github.com/Eppo-exp/golang-sdk/v2/eppoclient"
+  "github.com/Eppo-exp/golang-sdk/v4/eppoclient"
   "gopkg.in/segmentio/analytics-go.v3"
 )
 

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -37,7 +37,7 @@ func (ec *EppoClient) GetBoolAssignment(flagKey string, subjectKey string, subje
 }
 
 func (ec *EppoClient) GetNumericAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue float64) (float64, error) {
-	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, numericVariation)
+	variation, err := ec.getAssignment(flagKey, subjectKey, subjectAttributes, numericVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -49,7 +49,7 @@ func (ec *EppoClient) GetNumericAssignment(flagKey string, subjectKey string, su
 }
 
 func (ec *EppoClient) GetIntegerAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue int64) (int64, error) {
-	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, integerVariation)
+	variation, err := ec.getAssignment(flagKey, subjectKey, subjectAttributes, integerVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -61,7 +61,7 @@ func (ec *EppoClient) GetIntegerAssignment(flagKey string, subjectKey string, su
 }
 
 func (ec *EppoClient) GetStringAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue string) (string, error) {
-	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, stringVariation)
+	variation, err := ec.getAssignment(flagKey, subjectKey, subjectAttributes, stringVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -73,7 +73,7 @@ func (ec *EppoClient) GetStringAssignment(flagKey string, subjectKey string, sub
 }
 
 func (ec *EppoClient) GetJSONAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue interface{}) (interface{}, error) {
-	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, jsonVariation)
+	variation, err := ec.getAssignment(flagKey, subjectKey, subjectAttributes, jsonVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -24,8 +24,8 @@ func newEppoClient(configRequestor iConfigRequestor, poller *poller, assignmentL
 	return ec
 }
 
-func (ec *EppoClient) GetBoolAssignment(subjectKey string, flagKey string, subjectAttributes SubjectAttributes, defaultValue bool) (bool, error) {
-	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, booleanVariation)
+func (ec *EppoClient) GetBoolAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue bool) (bool, error) {
+	variation, err := ec.getAssignment(flagKey, subjectKey, subjectAttributes, booleanVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -36,8 +36,8 @@ func (ec *EppoClient) GetBoolAssignment(subjectKey string, flagKey string, subje
 	return result, err
 }
 
-func (ec *EppoClient) GetNumericAssignment(subjectKey string, flagKey string, subjectAttributes SubjectAttributes, defaultValue float64) (float64, error) {
-	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, numericVariation)
+func (ec *EppoClient) GetNumericAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue float64) (float64, error) {
+	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, numericVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -48,8 +48,8 @@ func (ec *EppoClient) GetNumericAssignment(subjectKey string, flagKey string, su
 	return result, err
 }
 
-func (ec *EppoClient) GetIntegerAssignment(subjectKey string, flagKey string, subjectAttributes SubjectAttributes, defaultValue int64) (int64, error) {
-	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, integerVariation)
+func (ec *EppoClient) GetIntegerAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue int64) (int64, error) {
+	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, integerVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -60,8 +60,8 @@ func (ec *EppoClient) GetIntegerAssignment(subjectKey string, flagKey string, su
 	return result, err
 }
 
-func (ec *EppoClient) GetStringAssignment(subjectKey string, flagKey string, subjectAttributes SubjectAttributes, defaultValue string) (string, error) {
-	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, stringVariation)
+func (ec *EppoClient) GetStringAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue string) (string, error) {
+	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, stringVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -72,15 +72,15 @@ func (ec *EppoClient) GetStringAssignment(subjectKey string, flagKey string, sub
 	return result, err
 }
 
-func (ec *EppoClient) GetJSONAssignment(subjectKey string, flagKey string, subjectAttributes SubjectAttributes, defaultValue interface{}) (interface{}, error) {
-	variation, err := ec.getAssignment(subjectKey, flagKey, subjectAttributes, jsonVariation)
+func (ec *EppoClient) GetJSONAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, defaultValue interface{}) (interface{}, error) {
+	variation, err := ec.getAssignment(flagKey, subjectKey,subjectAttributes, jsonVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
 	return variation, err
 }
 
-func (ec *EppoClient) getAssignment(subjectKey string, flagKey string, subjectAttributes SubjectAttributes, variationType variationType) (interface{}, error) {
+func (ec *EppoClient) getAssignment(flagKey string, subjectKey string, subjectAttributes SubjectAttributes, variationType variationType) (interface{}, error) {
 	if subjectKey == "" {
 		panic("no subject key provided")
 	}

--- a/eppoclient/client_test.go
+++ b/eppoclient/client_test.go
@@ -15,7 +15,7 @@ func Test_AssignBlankExperiment(t *testing.T) {
 	client := newEppoClient(mockConfigRequestor, poller, mockLogger)
 
 	assert.Panics(t, func() {
-		_, err := client.GetStringAssignment("subject-1", "", SubjectAttributes{}, "")
+		_, err := client.GetStringAssignment("", "subject-1", SubjectAttributes{}, "")
 		if err != nil {
 			log.Println(err)
 		}
@@ -29,7 +29,7 @@ func Test_AssignBlankSubject(t *testing.T) {
 	client := newEppoClient(mockConfigRequestor, poller, mockLogger)
 
 	assert.Panics(t, func() {
-		_, err := client.GetStringAssignment("", "experiment-1", SubjectAttributes{}, "")
+		_, err := client.GetStringAssignment("experiment-1", "", SubjectAttributes{}, "")
 		if err != nil {
 			log.Println(err)
 		}
@@ -82,7 +82,7 @@ func Test_LogAssignment(t *testing.T) {
 
 	client := newEppoClient(mockConfigRequestor, poller, mockLogger)
 
-	assignment, err := client.GetStringAssignment("user-1", "experiment-key-1", SubjectAttributes{}, "")
+	assignment, err := client.GetStringAssignment("experiment-key-1", "user-1",SubjectAttributes{}, "")
 	expected := "control"
 
 	assert.Nil(t, err)
@@ -136,7 +136,7 @@ func Test_GetStringAssignmentHandlesLoggingPanic(t *testing.T) {
 
 	client := newEppoClient(mockConfigRequestor, poller, mockLogger)
 
-	assignment, err := client.GetStringAssignment("user-1", "experiment-key-1", SubjectAttributes{}, "")
+	assignment, err := client.GetStringAssignment("experiment-key-1", "user-1", SubjectAttributes{}, "")
 	expected := "control"
 
 	assert.Nil(t, err)

--- a/eppoclient/doc.go
+++ b/eppoclient/doc.go
@@ -5,7 +5,7 @@
 	Usage:
 
 	import (
-		"github.com/Eppo-exp/golang-sdk/v2/eppoclient"
+		"github.com/Eppo-exp/golang-sdk/v4/eppoclient"
 	)
 
 	var eppoClient = &eppoclient.EppoClient{}
@@ -18,7 +18,7 @@
 	}
 
 	func apiEndpoint() {
-		assignment, _ := eppoClient.GetStringAssignment("subject-1", "experiment_5", sbjAttrs)
+		assignment, _ := eppoClient.GetStringAssignment("experiment_5", "subject-1", sbjAttrs, "control")
 
 		if assignment == "control" {
 			// do something

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -47,20 +47,20 @@ func Test_e2e(t *testing.T) {
 				t.Run(subject.SubjectKey, func(t *testing.T) {
 					switch test.VariationType {
 					case booleanVariation:
-						value, _ := client.GetBoolAssignment(subject.SubjectKey, test.Flag, subject.SubjectAttributes, test.DefaultValue.(bool))
+						value, _ := client.GetBoolAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, test.DefaultValue.(bool))
 						assert.Equal(t, subject.Assignment, value)
 					case numericVariation:
-						value, _ := client.GetNumericAssignment(subject.SubjectKey, test.Flag, subject.SubjectAttributes, test.DefaultValue.(float64))
+						value, _ := client.GetNumericAssignment(test.Flag, ssubject.SubjectKey, ubject.SubjectAttributes, test.DefaultValue.(float64))
 						assert.Equal(t, subject.Assignment, value)
 					case integerVariation:
-						value, _ := client.GetIntegerAssignment(subject.SubjectKey, test.Flag, subject.SubjectAttributes, int64(test.DefaultValue.(float64)))
+						value, _ := client.GetIntegerAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, int64(test.DefaultValue.(float64)))
 						assert.Equal(t, int64(subject.Assignment.(float64)), value)
 
 					case jsonVariation:
-						value, _ := client.GetJSONAssignment(subject.SubjectKey, test.Flag, subject.SubjectAttributes, test.DefaultValue)
+						value, _ := client.GetJSONAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, test.DefaultValue)
 						assert.Equal(t, subject.Assignment, value)
 					case stringVariation:
-						value, _ := client.GetStringAssignment(subject.SubjectKey, test.Flag, subject.SubjectAttributes, test.DefaultValue.(string))
+						value, _ := client.GetStringAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, test.DefaultValue.(string))
 						assert.Equal(t, subject.Assignment, value)
 					default:
 						panic(fmt.Sprintf("unknown variation: %v", test.VariationType))

--- a/eppoclient/eppoclient_e2e_test.go
+++ b/eppoclient/eppoclient_e2e_test.go
@@ -50,7 +50,7 @@ func Test_e2e(t *testing.T) {
 						value, _ := client.GetBoolAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, test.DefaultValue.(bool))
 						assert.Equal(t, subject.Assignment, value)
 					case numericVariation:
-						value, _ := client.GetNumericAssignment(test.Flag, ssubject.SubjectKey, ubject.SubjectAttributes, test.DefaultValue.(float64))
+						value, _ := client.GetNumericAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, test.DefaultValue.(float64))
 						assert.Equal(t, subject.Assignment, value)
 					case integerVariation:
 						value, _ := client.GetIntegerAssignment(test.Flag, subject.SubjectKey, subject.SubjectAttributes, int64(test.DefaultValue.(float64)))

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -4,7 +4,7 @@ package eppoclient
 
 import "net/http"
 
-var __version__ = "3.0.0"
+var __version__ = "4.0.0"
 
 // InitClient is required to start polling of experiments configurations and create
 // an instance of EppoClient, which could be used to get assignments information.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Eppo-exp/golang-sdk/v3
+module github.com/Eppo-exp/golang-sdk/v4
 
 go 1.19
 


### PR DESCRIPTION
We forgot to update the ordering of arguments for the `get_assignment` functions -- fixed here