### PR TITLE
perf: [do not deserialize json objects or update local cache if remote response has not changed from the previous one] (FF-2576)

### DIFF
--- a/eppoclient/configurationrequestor_test.go
+++ b/eppoclient/configurationrequestor_test.go
@@ -1,0 +1,108 @@
+package eppoclient
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockHttpClient struct {
+	mock.Mock
+}
+
+func (m *mockHttpClient) get(url string) (string, error) {
+	args := m.Called(url)
+	return args.String(0), args.Error(1)
+}
+
+func Test_FetchAndStoreConfigurations_DoesNotDeserializeTwice(t *testing.T) {
+	mockHttpClient := new(mockHttpClient)
+	mockConfigStore := newConfigurationStore()
+	configRequestor := newConfigurationRequestor(mockHttpClient, mockConfigStore)
+
+	// Mock the HTTP client to return a fixed response
+	mockResponse1 := `
+	{
+		"createdAt": "2024-04-17T19:40:53.716Z",
+		"environment": {
+			"name": "Test"
+		},
+		"flags": {
+			"empty_flag": {
+				"key": "empty_flag",
+				"enabled": true,
+				"variationType": "STRING",
+				"variations": {},
+				"allocations": [],
+				"totalShards": 10000
+			}
+		}
+	}
+	`
+	mockCall := mockHttpClient.On("get", UFC_ENDPOINT).Return(mockResponse1, nil)
+
+	// First fetch and store configurations
+	configRequestor.FetchAndStoreConfigurations()
+
+	// Store the current hash
+	firstHash := configRequestor.storedFlagConfigsHash
+
+	// Fetch and store configurations again
+	configRequestor.FetchAndStoreConfigurations()
+
+	// Store the hash after the second fetch
+	secondHash := configRequestor.storedFlagConfigsHash
+
+	// Assert that the hash has not changed
+	assert.Equal(t, firstHash, secondHash)
+
+	// Assert that the configurations were only deserialized once
+	assert.Equal(t, 1, len(mockConfigStore.configs))
+	assert.Equal(t, "empty_flag", mockConfigStore.configs["empty_flag"].Key)
+	mockHttpClient.AssertNumberOfCalls(t, "get", 2)
+	mockCall.Unset()
+
+	// change the remote config
+	mockResponse2 := `
+	{
+		"createdAt": "2024-04-17T19:40:53.716Z",
+		"environment": {
+			"name": "Test"
+		},
+		"flags": {
+			"empty_flag_2": {
+				"key": "empty_flag_2",
+				"enabled": true,
+				"variationType": "STRING",
+				"variations": {},
+				"allocations": [],
+				"totalShards": 10000
+			}
+		}
+	}
+	`
+	mockCall = mockHttpClient.On("get", UFC_ENDPOINT).Return(mockResponse2, nil)
+
+	// fetch and store again
+	configRequestor.FetchAndStoreConfigurations()
+
+	// assert that the new config is stored
+	assert.Equal(t, 1, len(mockConfigStore.configs))
+	fmt.Println(mockConfigStore.configs)
+	assert.Equal(t, "empty_flag_2", mockConfigStore.configs["empty_flag_2"].Key)
+	mockHttpClient.AssertNumberOfCalls(t, "get", 3)
+	mockCall.Unset()
+
+	// change remote config back to original
+	mockCall = mockHttpClient.On("get", UFC_ENDPOINT).Return(mockResponse1, nil)
+
+	// fetch and store again
+	configRequestor.FetchAndStoreConfigurations()
+
+	assert.Equal(t, 1, len(mockConfigStore.configs))
+	assert.Equal(t, "empty_flag", mockConfigStore.configs["empty_flag"].Key)
+	mockHttpClient.AssertNumberOfCalls(t, "get", 4)
+	mockCall.Unset()
+}

--- a/eppoclient/httpclient.go
+++ b/eppoclient/httpclient.go
@@ -10,11 +10,14 @@ import (
 
 const REQUEST_TIMEOUT_SECONDS = time.Duration(10 * time.Second)
 
+type HttpClientInterface interface {
+	get(resource string) (string, error)
+}
+
 type httpClient struct {
-	baseUrl        string
-	sdkParams      SDKParams
-	isUnauthorized bool
-	client         *http.Client
+	baseUrl   string
+	sdkParams SDKParams
+	client    *http.Client
 }
 
 type SDKParams struct {
@@ -23,12 +26,11 @@ type SDKParams struct {
 	sdkVersion string
 }
 
-func newHttpClient(baseUrl string, client *http.Client, sdkParams SDKParams) *httpClient {
+func newHttpClient(baseUrl string, client *http.Client, sdkParams SDKParams) HttpClientInterface {
 	var hc = &httpClient{
-		baseUrl:        baseUrl,
-		sdkParams:      sdkParams,
-		isUnauthorized: false,
-		client:         client,
+		baseUrl:   baseUrl,
+		sdkParams: sdkParams,
+		client:    client,
 	}
 	return hc
 }
@@ -64,7 +66,6 @@ func (hc *httpClient) get(resource string) (string, error) {
 	defer resp.Body.Close() // Ensure the response body is closed
 
 	if resp.StatusCode == 401 {
-		hc.isUnauthorized = true
 		return "", fmt.Errorf("unauthorized access") // Return an error indicating unauthorized access
 	}
 

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -4,7 +4,7 @@ package eppoclient
 
 import "net/http"
 
-var __version__ = "4.0.1"
+var __version__ = "4.0.2"
 
 // InitClient is required to start polling of experiments configurations and create
 // an instance of EppoClient, which could be used to get assignments information.
@@ -14,7 +14,7 @@ func InitClient(config Config) *EppoClient {
 
 	httpClient := newHttpClient(config.BaseUrl, &http.Client{Timeout: REQUEST_TIMEOUT_SECONDS}, sdkParams)
 	configStore := newConfigurationStore()
-	requestor := newConfigurationRequestor(*httpClient, configStore)
+	requestor := newConfigurationRequestor(httpClient, configStore)
 	assignmentLogger := config.AssignmentLogger
 
 	poller := newPoller(config.PollerInterval, requestor.FetchAndStoreConfigurations)


### PR DESCRIPTION
## motivation

Following integrating the Eppo SDK into their server, we have a customer report of high CPU and memory utilization.

The default polling interval on golang is every 10 seconds and almost always the flag configuration from the CDN is not changed. However each of these refreshes the SDK deserialized the JSON into go objects and updates the cache.

## proposed changes

Only perform json deserialization if the received response is different than the cached version. This is determined by storing the hash of the received bytes.

The hash is computed over the entire response object, including a parameter called `createdAt` which is not currently in-use. This field corresponds to changes in the configuration and does not change between cached versions so is safe to treat as part of the payload.

## rollout

It is unknown whether this change will fully mitigate the high memory utilization. We have another changes in scope.

## for reviewers

* Do you think this behavior should be configurable during initialization with a flag?
* Do you see any risks of the SDK getting stale?