### PR TITLE
Return sentinel errors to help handling by callers

### DIFF
--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -1,7 +1,6 @@
 package eppoclient
 
 import (
-	"errors"
 	"sync/atomic"
 )
 
@@ -50,7 +49,7 @@ func (c configuration) getBanditVariant(flagKey, variation string) (result bandi
 func (c configuration) getFlagConfiguration(key string) (flagConfiguration, error) {
 	flag, ok := c.flags.Flags[key]
 	if !ok {
-		return flag, errors.New("flag configuration not found")
+		return flag, ErrFlagConfigurationNotFound
 	}
 
 	return flag, nil
@@ -59,7 +58,7 @@ func (c configuration) getFlagConfiguration(key string) (flagConfiguration, erro
 func (c configuration) getBanditConfiguration(key string) (banditConfiguration, error) {
 	bandit, ok := c.bandits.Bandits[key]
 	if !ok {
-		return bandit, errors.New("bandit configuration not found")
+		return bandit, ErrBanditConfigurationNotFound
 	}
 
 	return bandit, nil

--- a/eppoclient/errors.go
+++ b/eppoclient/errors.go
@@ -1,0 +1,10 @@
+package eppoclient
+
+import "errors"
+
+var (
+	ErrSubjectAllocation           = errors.New("subject is not part of any allocation")
+	ErrFlagNotEnabled              = errors.New("the experiment or flag is not enabled")
+	ErrFlagConfigurationNotFound   = errors.New("flag configuration not found")
+	ErrBanditConfigurationNotFound = errors.New("bandit configuration not found")
+)

--- a/eppoclient/evalflags.go
+++ b/eppoclient/evalflags.go
@@ -1,7 +1,6 @@
 package eppoclient
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -18,7 +17,7 @@ func (flag flagConfiguration) verifyType(ty variationType) error {
 
 func (flag flagConfiguration) eval(subjectKey string, subjectAttributes Attributes, applicationLogger applicationlogger.Logger) (interface{}, *AssignmentEvent, error) {
 	if !flag.Enabled {
-		return nil, nil, errors.New("the experiment or flag is not enabled")
+		return nil, nil, ErrFlagNotEnabled
 	}
 
 	now := time.Now()
@@ -34,7 +33,7 @@ func (flag flagConfiguration) eval(subjectKey string, subjectAttributes Attribut
 		}
 	}
 	if allocation == nil || split == nil {
-		return nil, nil, errors.New("subject is not part of any allocation")
+		return nil, nil, ErrSubjectAllocation
 	}
 
 	variation, ok := flag.Variations[split.VariationKey]

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -4,7 +4,7 @@ package eppoclient
 
 import "net/http"
 
-var __version__ = "5.0.0"
+var __version__ = "5.1.0"
 
 // InitClient is required to start polling of experiments configurations and create
 // an instance of EppoClient, which could be used to get assignments information.


### PR DESCRIPTION
Hi Eppo team,
my team wants to be able to handle the cases where flag is not found/not enabled better and I think it'd be more convenient to define these errors as (public) vars so they can be handled more nicely with `errors.Is( ... )`

thanks!