### PR TITLE
fix: Handle empty actions list and high-score tiebreaking

### DIFF
--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -103,24 +103,19 @@ type BanditResult struct {
 func (ec *EppoClient) GetBanditAction(flagKey string, subjectKey string, subjectAttributes ContextAttributes, actions map[string]ContextAttributes, defaultVariation string) BanditResult {
 	config := ec.configurationStore.getConfiguration()
 
-	isBanditFlag := config.isBanditFlag(flagKey)
-
-	if isBanditFlag && len(actions) == 0 {
-		// No actions passed for a flag known to have an
-		// active bandit, so we just return the default values
-		// so that we don't log a variation or bandit
-		// assignment.
-		return BanditResult{
-			Variation: defaultVariation,
-			Action:    nil,
-		}
-	}
-
 	// ignoring the error here as we can always proceed with default variation
 	assignmentValue, _ := ec.getAssignment(config, flagKey, subjectKey, subjectAttributes.toGenericAttributes(), stringVariation)
 	variation, ok := assignmentValue.(string)
 	if !ok {
 		variation = defaultVariation
+	}
+
+	// If no acctions have been passed, we will return the variation, even if it is a bandit key
+	if len(actions) == 0 {
+		return BanditResult{
+			Variation: variation,
+			Action:    nil,
+		}
 	}
 
 	banditVariation, ok := config.getBanditVariant(flagKey, variation)

--- a/eppoclient/configurationstore.go
+++ b/eppoclient/configurationstore.go
@@ -31,12 +31,6 @@ func (c *configuration) refreshBanditFlagAssociations() {
 	c.banditFlagAssociations = associations
 }
 
-// Return `true` if `flagKey` has associated bandits.
-func (c configuration) isBanditFlag(flagKey string) bool {
-	_, ok := c.banditFlagAssociations[flagKey]
-	return ok
-}
-
 func (c configuration) getBanditVariant(flagKey, variation string) (result banditVariation, ok bool) {
 	byVariation, ok := c.banditFlagAssociations[flagKey]
 	if !ok {

--- a/eppoclient/evalbandits.go
+++ b/eppoclient/evalbandits.go
@@ -103,7 +103,7 @@ func (model *banditModelData) evaluate(ctx banditEvaluationContext) banditEvalua
 
 	bestAction, bestScore := "", math.Inf(-1)
 	for actionKey, score := range scores {
-		if score > bestScore {
+		if score > bestScore || (score == bestScore && actionKey < bestAction) {
 			bestAction, bestScore = actionKey, score
 		}
 	}

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -4,7 +4,7 @@ package eppoclient
 
 import "net/http"
 
-var __version__ = "5.1.0"
+var __version__ = "5.1.1"
 
 // InitClient is required to start polling of experiments configurations and create
 // an instance of EppoClient, which could be used to get assignments information.


### PR DESCRIPTION
🎟️ fixes FF-3068 FF-3069

### Motivation and Context
Tweaks to the bandit selection algorithm decided after implementation of some SDKs has led to some falling behind in feature/fix parity. The SDK test data repository tests each SDK, but within its own workflows, so when new tests break the SDK, it stays green until a new PR.

### Description
- When two actions have the same high score, pick the smaller one, lexicographically
- When evaluating bandits, compute the string assignment, then check whether any actions were passed. 

### Tests
Passing!