### PR TITLE
fix: Properly use templated version of logging calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ eppoclient/test-data
 
 .DS_Store
 memprofile*
+.idea/
+pkg/

--- a/eppoclient/applicationlogger/interface.go
+++ b/eppoclient/applicationlogger/interface.go
@@ -3,6 +3,9 @@ package applicationlogger
 type Logger interface {
 	Debug(args ...interface{})
 	Info(args ...interface{})
+	Infof(template string, args ...interface{})
 	Warn(args ...interface{})
+	Warnf(template string, args ...interface{})
 	Error(args ...interface{})
+	Errorf(template string, args ...interface{})
 }

--- a/eppoclient/applicationlogger/scrubbing_logger.go
+++ b/eppoclient/applicationlogger/scrubbing_logger.go
@@ -44,10 +44,22 @@ func (s *ScrubbingLogger) Info(args ...interface{}) {
 	s.innerLogger.Info(s.scrub(args...)...)
 }
 
+func (s *ScrubbingLogger) Infof(template string, args ...interface{}) {
+	s.innerLogger.Infof(maskSensitiveInfo(template), s.scrub(args...)...)
+}
+
 func (s *ScrubbingLogger) Warn(args ...interface{}) {
 	s.innerLogger.Warn(s.scrub(args...)...)
 }
 
+func (s *ScrubbingLogger) Warnf(template string, args ...interface{}) {
+	s.innerLogger.Warnf(maskSensitiveInfo(template), s.scrub(args...)...)
+}
+
 func (s *ScrubbingLogger) Error(args ...interface{}) {
 	s.innerLogger.Error(s.scrub(args...)...)
+}
+
+func (s *ScrubbingLogger) Errorf(template string, args ...interface{}) {
+	s.innerLogger.Errorf(maskSensitiveInfo(template), s.scrub(args...)...)
 }

--- a/eppoclient/applicationlogger/zap_logger.go
+++ b/eppoclient/applicationlogger/zap_logger.go
@@ -4,9 +4,7 @@ import (
 	"go.uber.org/zap"
 )
 
-/**
- * The default logger for the SDK.
- */
+// ZapLogger The default logger for the Eppo SDK
 type ZapLogger struct {
 	logger *zap.Logger
 }
@@ -23,10 +21,22 @@ func (z *ZapLogger) Info(args ...interface{}) {
 	z.logger.Sugar().Info(args...)
 }
 
+func (z *ZapLogger) Infof(template string, args ...interface{}) {
+	z.logger.Sugar().Infof(template, args...)
+}
+
 func (z *ZapLogger) Warn(args ...interface{}) {
 	z.logger.Sugar().Warn(args...)
 }
 
+func (z *ZapLogger) Warnf(template string, args ...interface{}) {
+	z.logger.Sugar().Warnf(template, args...)
+}
+
 func (z *ZapLogger) Error(args ...interface{}) {
 	z.logger.Sugar().Error(args...)
+}
+
+func (z *ZapLogger) Errorf(template string, args ...interface{}) {
+	z.logger.Sugar().Errorf(template, args...)
 }

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -9,7 +9,7 @@ import (
 
 type Attributes map[string]interface{}
 
-// Client for eppo.cloud. Instance of this struct will be created on calling InitClient.
+// EppoClient Client for eppo.cloud. Instance of this struct will be created on calling InitClient.
 // EppoClient will then immediately start polling experiments data from Eppo.
 type EppoClient struct {
 	configurationStore *configurationStore
@@ -42,7 +42,7 @@ func (ec *EppoClient) GetBoolAssignment(flagKey string, subjectKey string, subje
 	}
 	result, ok := variation.(bool)
 	if !ok {
-		ec.applicationLogger.Error("failed to cast %v to bool", variation)
+		ec.applicationLogger.Errorf("failed to cast %v to bool", variation)
 		return defaultValue, fmt.Errorf("failed to cast %v to bool", variation)
 	}
 	return result, err
@@ -55,7 +55,7 @@ func (ec *EppoClient) GetNumericAssignment(flagKey string, subjectKey string, su
 	}
 	result, ok := variation.(float64)
 	if !ok {
-		ec.applicationLogger.Error("failed to cast %v to float64", variation)
+		ec.applicationLogger.Errorf("failed to cast %v to float64", variation)
 		return defaultValue, fmt.Errorf("failed to cast %v to float64", variation)
 	}
 	return result, err
@@ -68,7 +68,7 @@ func (ec *EppoClient) GetIntegerAssignment(flagKey string, subjectKey string, su
 	}
 	result, ok := variation.(int64)
 	if !ok {
-		ec.applicationLogger.Error("failed to cast %v to int64", variation)
+		ec.applicationLogger.Errorf("failed to cast %v to int64", variation)
 		return defaultValue, fmt.Errorf("failed to cast %v to int64", variation)
 	}
 	return result, err
@@ -81,7 +81,7 @@ func (ec *EppoClient) GetStringAssignment(flagKey string, subjectKey string, sub
 	}
 	result, ok := variation.(string)
 	if !ok {
-		ec.applicationLogger.Error("failed to cast %v to string", variation)
+		ec.applicationLogger.Errorf("failed to cast %v to string", variation)
 		return defaultValue, fmt.Errorf("failed to cast %v to string", variation)
 	}
 	return result, err
@@ -110,7 +110,7 @@ func (ec *EppoClient) GetBanditAction(flagKey string, subjectKey string, subject
 		variation = defaultVariation
 	}
 
-	// If no acctions have been passed, we will return the variation, even if it is a bandit key
+	// If no actions have been passed, we will return the variation, even if it is a bandit key
 	if len(actions) == 0 {
 		return BanditResult{
 			Variation: variation,
@@ -192,19 +192,19 @@ func (ec *EppoClient) getAssignment(config configuration, flagKey string, subjec
 
 	flag, err := config.getFlagConfiguration(flagKey)
 	if err != nil {
-		ec.applicationLogger.Info("failed to get flag configuration: %v", err)
+		ec.applicationLogger.Infof("failed to get flag configuration: %v", err)
 		return nil, err
 	}
 
 	err = flag.verifyType(variationType)
 	if err != nil {
-		ec.applicationLogger.Info("failed to verify flag type: %v", err)
+		ec.applicationLogger.Warnf("failed to verify flag type: %v", err)
 		return nil, err
 	}
 
 	assignmentValue, assignmentEvent, err := flag.eval(subjectKey, subjectAttributes, ec.applicationLogger)
 	if err != nil {
-		ec.applicationLogger.Info("failed to evaluate flag: %v", err)
+		ec.applicationLogger.Errorf("failed to evaluate flag: %v", err)
 		return nil, err
 	}
 
@@ -214,7 +214,7 @@ func (ec *EppoClient) getAssignment(config configuration, flagKey string, subjec
 			defer func() {
 				r := recover()
 				if r != nil {
-					ec.applicationLogger.Error("panic occurred: %v", r)
+					ec.applicationLogger.Errorf("panic occurred: %v", r)
 				}
 			}()
 

--- a/eppoclient/utils_test.go
+++ b/eppoclient/utils_test.go
@@ -37,7 +37,7 @@ func TestToFloat64(t *testing.T) {
 				t.Errorf("ToFloat64(%v) error = %v, expectErr %v", tt.input, err, tt.expectErr)
 				return
 			}
-			closeEnough := math.Abs(result - tt.expected)/tt.expected < 0.00001
+			closeEnough := math.Abs(result-tt.expected)/tt.expected < 0.00001
 			if !tt.expectErr && !closeEnough {
 				t.Errorf("ToFloat64(%v) = %v, want %v", tt.input, result, tt.expected)
 			}


### PR DESCRIPTION
Also changed some logging calls for error states which were incorrectly using `info`