### PR TITLE
bug: [Do not log assignment when DoLog is absent or not explicitly true] (FF-3109)

### DIFF
--- a/eppoclient/evalflags.go
+++ b/eppoclient/evalflags.go
@@ -47,7 +47,7 @@ func (flag flagConfiguration) eval(subjectKey string, subjectAttributes Attribut
 	}
 
 	var assignmentEvent *AssignmentEvent
-	if allocation.DoLog == nil || *allocation.DoLog {
+	if allocation.DoLog != nil && *allocation.DoLog {
 		assignmentEvent = &AssignmentEvent{
 			FeatureFlag:       flag.Key,
 			Allocation:        allocation.Key,

--- a/eppoclient/evalflags.go
+++ b/eppoclient/evalflags.go
@@ -47,7 +47,7 @@ func (flag flagConfiguration) eval(subjectKey string, subjectAttributes Attribut
 	}
 
 	var assignmentEvent *AssignmentEvent
-	if allocation.DoLog != nil && *allocation.DoLog {
+	if allocation.DoLog == nil || *allocation.DoLog {
 		assignmentEvent = &AssignmentEvent{
 			FeatureFlag:       flag.Key,
 			Allocation:        allocation.Key,


### PR DESCRIPTION
## Observation

* Customer started an experiment with 1% percent exposure.
* They saw 100x the assignment volume

After investigating the cause, found that the default allocation was responsible for the overage. We should not be logging these events.

🎫 https://linear.app/eppo/issue/FF-3109/kargo-experiment-generated-much-more-exposures-than-expected

## Changes

Only log when `DoLog` on an allocation is explicitly `true`