### PR TITLE
fix: proxy LogBanditAction through LruAssignmentLogger

### DIFF
--- a/eppoclient/lruassignmentlogger.go
+++ b/eppoclient/lruassignmentlogger.go
@@ -11,10 +11,6 @@ type LruAssignmentLogger struct {
 	inner IAssignmentLogger
 }
 
-// We are only interested in whether a subject was ever a part of an
-// assignment. We are not interested in the order of assignments or
-// knowing the latest assignment. Therefore, both allocation and
-// variation are part of the cacheKey.
 type cacheKey struct {
 	flag    string
 	subject string
@@ -52,5 +48,11 @@ func (lal *LruAssignmentLogger) LogAssignment(event AssignmentEvent) {
 		// Adding to cache after `LogAssignment` returned in
 		// case it panics.
 		lal.cache.Add(key, value)
+	}
+}
+
+func (lal *LruAssignmentLogger) LogBanditAction(event BanditEvent) {
+	if logger, ok := lal.inner.(BanditActionLogger); ok {
+		logger.LogBanditAction(event)
 	}
 }

--- a/eppoclient/lruassignmentlogger_test.go
+++ b/eppoclient/lruassignmentlogger_test.go
@@ -237,3 +237,35 @@ func Test_LruAssignmentLogger_variationOscillationLogsAll(t *testing.T) {
 
 	innerLogger.AssertNumberOfCalls(t, "LogAssignment", 4)
 }
+
+func Test_LruAssignmentLogger_proxyLogBanditAction(t *testing.T) {
+	innerLogger := new(mockLogger)
+	innerLogger.On("LogAssignment", mock.Anything).Return()
+	innerLogger.On("LogBanditAction", mock.Anything).Return()
+
+	logger, err := NewLruAssignmentLogger(innerLogger, 1000)
+	assert.NoError(t, err)
+
+	event := BanditEvent{
+		FlagKey:                      "flag",
+		BanditKey:                    "bandit",
+		Subject:                      "subject",
+		Action:                       "action",
+		ActionProbability:            0.1,
+		OptimalityGap:                0.1,
+		ModelVersion:                 "model-version",
+		Timestamp:                    "timestamp",
+		SubjectNumericAttributes:     map[string]float64{},
+		SubjectCategoricalAttributes: map[string]string{},
+		ActionNumericAttributes:      map[string]float64{},
+		ActionCategoricalAttributes:  map[string]string{},
+		MetaData:                     map[string]string{},
+	}
+
+	banditLogger := logger.(BanditActionLogger)
+
+	banditLogger.LogBanditAction(event)
+	banditLogger.LogBanditAction(event)
+
+	innerLogger.AssertNumberOfCalls(t, "LogBanditAction", 2)
+}


### PR DESCRIPTION
`LruAssignmentLogger` did not have `LogBanditAction` which means it was masking the bandit logger of the inner logger