### PR TITLE
quality: parameterize sdk and test data branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,9 @@
 name: Test SDK
+
+env:
+  SDK_BRANCH_NAME: ${{ inputs.sdk_branch  || github.head_ref || github.ref_name || 'main' }}
+  TEST_DATA_BRANCH_NAME: ${{ inputs.test_data_branch || 'main' }}
+
 on:
   pull_request:
     paths:
@@ -6,12 +11,27 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
+  workflow_call:
+    inputs:
+      test_data_branch:
+        type: string
+        description: The branch in sdk-test-data to target for testcase files
+        required: false
+        default: main
+      sdk_branch:
+        type: string
+        description: The branch of the SDK to test
+        required: false
 jobs:
   test-sdk:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/golang-sdk
+          ref: ${{ env.SDK_BRANCH_NAME}}
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
@@ -20,4 +40,4 @@ jobs:
       - name: 'Set up GCP SDK for downloading test data'
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: Test
-        run: make test
+        run: make test branchName=${{env.TEST_DATA_BRANCH_NAME}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,5 @@ jobs:
           go-version: 1.19
       - name: Build
         run: go build -v ./...
-      - name: 'Set up GCP SDK for downloading test data'
-        uses: 'google-github-actions/setup-gcloud@v0'
       - name: Test
         run: make test branchName=${{env.TEST_DATA_BRANCH_NAME}}


### PR DESCRIPTION
🎟️ Fixes FF-3087 towards FF-3085

👯‍♂️ **Related PRs**

- [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/pull/59)
- [react-native-sdk](https://github.com/Eppo-exp/react-native-sdk/pull/58)
- [ios-sdk](https://github.com/Eppo-exp/eppo-ios-sdk/pull/40)
- [android-sdk](https://github.com/Eppo-exp/android-sdk/pull/93)


### Motivation
Changes are often made to the [sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) repository to capture new behaviours, bugs and edge cases. When these changes are pushed to `main`, the SDKs are cloned locally (locally to the github action running) and their respective tests are run. These tests are set up and run by copies of the SDK test workflows - see [sdk-test-data workflow](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows/test-sdks.yml). There are a number of limitations to this setup:

- Test steps are copied from the SDK’s respective workflows; changes to the SDK test workflows need to be replicated in sdk-test-data and this is not obvious to devs
- The SDK tests are not able to run against in-flight changes to `sdk-test-data`
- When new test-data is committed that breaks an SDK, that breakage is not surfaced in the SDK’s repository until some action triggers its testing workflow (on demand, on pull-request, etc.).

### Description of Changes
_This change_
🚀 - Each SDK's testing workflow is enhanced into a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows), exposing parameters for SDK branch and the sdk-test-data branch to use in testing.
- The test workflow runs using the main branch of sdk-test-data on all main pushes and Pull Requests using the PR's branch

_External to this Change_
[sdk-test-data](https://github.com/Eppo-exp/sdk-test-data/blob/main/.github/workflows) get two testing workflows.
1. ♻️  "Local Testing"- For all pull request changes, the "Local Testing" workflow calls the reusable SDK workflows, test results are recorded only in the sdk-test-data action. This is run using the main SDK branch and the "current" branch of workflow, i.e. the pull request branch. (SDK repo does not see/is not notified of test failures during PR lifecycle, only on push to main)
2. ♻️ 🧑‍💻 "Remote Testing" - On all pushes to the main branch of sdk-test-data, the SDK testing workflows are triggered to run within their respective repositories, alerting all subscribers of failed runs (repo is red/green).