### PR TITLE
feat: allow passing custom http client

### DIFF
--- a/eppoclient/config.go
+++ b/eppoclient/config.go
@@ -2,6 +2,7 @@ package eppoclient
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"go.uber.org/zap"
@@ -16,6 +17,7 @@ type Config struct {
 	AssignmentLogger  IAssignmentLogger
 	PollerInterval    time.Duration
 	ApplicationLogger ApplicationLogger
+	HttpClient        *http.Client
 }
 
 func (cfg *Config) validate() error {

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -14,7 +14,13 @@ func InitClient(config Config) (*EppoClient, error) {
 	sdkParams := SDKParams{sdkKey: config.SdkKey, sdkName: "go", sdkVersion: __version__}
 	applicationLogger := config.ApplicationLogger
 
-	httpClient := newHttpClient(config.BaseUrl, &http.Client{Timeout: REQUEST_TIMEOUT_SECONDS}, sdkParams)
+	var httpClientInstance *http.Client
+	if config.HttpClient != nil {
+		httpClientInstance = config.HttpClient
+	} else {
+		httpClientInstance = &http.Client{Timeout: REQUEST_TIMEOUT_SECONDS}
+	}
+	httpClient := newHttpClient(config.BaseUrl, httpClientInstance, sdkParams)
 	configStore := newConfigurationStore()
 	requestor := newConfigurationRequestor(*httpClient, configStore, applicationLogger)
 


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes #74 
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

To allow tuning the HTTP client, such as TCP transportation config, to fix the issue reported in #74.

## Description
[//]: # (Describe your changes in detail)

With this change, when we initialize the Eppo client, we can pass in a custom HTTP client like this:

```
		var httpClientInstance *http.Client
		httpClientInstance = &http.Client{Timeout: 10 * time.Second}
		httpClientInstance.Transport = &http.Transport{
			Proxy: http.ProxyFromEnvironment,
			DialContext: (&net.Dialer{
				Timeout:   5 * time.Second,
				KeepAlive: 10 * time.Second,
			}).DialContext,
			MaxIdleConns:          100,
			IdleConnTimeout:       90 * time.Second,
			TLSHandshakeTimeout:   10 * time.Second,
			ExpectContinueTimeout: 1 * time.Second,
			ForceAttemptHTTP2:     true,
		}

		config := eppoclient.Config{
			SdkKey:            os.Getenv("EPPO_SDK_KEY"),
			PollerInterval:    5 * time.Second,
			ApplicationLogger: customLogger,
			HttpClient:        httpClientInstance,
		}

```

This parameter is optional, and if we don't specify it, the default behavior will be applied.

With the above config, the netstat output will look like this, where we have multiple TCP connection rotated.
```
/app $ netstat -a
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:43202 151.101.65.91:https     ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:44978 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:58722 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:50592 151.101.193.91:https    ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:58724 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:34132 151.101.129.91:https    ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:38196 151.101.193.91:https    ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:32936 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:44244 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:39742 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:42666 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:55332 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:43618 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:42682 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:39740 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:55334 151.101.1.91:https      ESTABLISHED
tcp        0      0 test-eppo-698b9bdcfd-8bjhf:44228 151.101.1.91:https      ESTABLISHED
```

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
