### PR TITLE
add get assignment methods with context

### DIFF
--- a/eppoclient/assignmentlogger.go
+++ b/eppoclient/assignmentlogger.go
@@ -1,9 +1,16 @@
 package eppoclient
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type IAssignmentLogger interface {
 	LogAssignment(event AssignmentEvent)
+}
+
+type IAssignmentLoggerContext interface {
+	LogAssignment(context.Context, AssignmentEvent)
 }
 
 // BanditActionLogger is going to be merged into IAssignmentLogger in

--- a/eppoclient/bandits_test.go
+++ b/eppoclient/bandits_test.go
@@ -61,7 +61,7 @@ func Test_bandits_sdkTestData(t *testing.T) {
 	logger := new(mockLogger)
 	logger.Mock.On("LogAssignment", mock.Anything).Return()
 	logger.Mock.On("LogBanditAction", mock.Anything).Return()
-	client := newEppoClient(configStore, nil, nil, logger, applicationLogger)
+	client := newEppoClient(configStore, nil, nil, logger, nil, applicationLogger)
 
 	tests := readJsonDirectory[banditTest]("test-data/ufc/bandit-tests/")
 	for file, test := range tests {

--- a/eppoclient/client.go
+++ b/eppoclient/client.go
@@ -1,6 +1,7 @@
 package eppoclient
 
 import (
+	"context"
 	"fmt"
 	"time"
 )
@@ -14,6 +15,7 @@ type EppoClient struct {
 	configRequestor    *configurationRequestor
 	poller             *poller
 	logger             IAssignmentLogger
+	loggerContext      IAssignmentLoggerContext
 	applicationLogger  ApplicationLogger
 }
 
@@ -22,6 +24,7 @@ func newEppoClient(
 	configRequestor *configurationRequestor,
 	poller *poller,
 	assignmentLogger IAssignmentLogger,
+	assignmentLoggerContext IAssignmentLoggerContext,
 	applicationLogger ApplicationLogger,
 ) *EppoClient {
 	return &EppoClient{
@@ -29,6 +32,7 @@ func newEppoClient(
 		configRequestor:    configRequestor,
 		poller:             poller,
 		logger:             assignmentLogger,
+		loggerContext:      assignmentLoggerContext,
 		applicationLogger:  applicationLogger,
 	}
 }
@@ -39,16 +43,38 @@ func newEppoClient(
 // It is recommended to apply a timeout to initialization as otherwise
 // it may hang up indefinitely.
 //
-//  select {
-//  case <-client.Initialized():
-//  case <-time.After(5 * time.Second):
-//  }
+//	select {
+//	case <-client.Initialized():
+//	case <-time.After(5 * time.Second):
+//	}
 func (ec *EppoClient) Initialized() <-chan struct{} {
 	return ec.configurationStore.Initialized()
 }
 
-func (ec *EppoClient) GetBoolAssignment(flagKey string, subjectKey string, subjectAttributes Attributes, defaultValue bool) (bool, error) {
-	variation, err := ec.getAssignment(ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, booleanVariation)
+func (ec *EppoClient) GetBoolAssignment(
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue bool,
+) (bool, error) {
+	return ec.getBoolAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) GetBoolAssignmentContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue bool,
+) (bool, error) {
+	return ec.getBoolAssignment(ctx, flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) getBoolAssignment(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue bool,
+) (bool, error) {
+	variation, err := ec.getAssignment(ctx, ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, booleanVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -60,8 +86,30 @@ func (ec *EppoClient) GetBoolAssignment(flagKey string, subjectKey string, subje
 	return result, err
 }
 
-func (ec *EppoClient) GetNumericAssignment(flagKey string, subjectKey string, subjectAttributes Attributes, defaultValue float64) (float64, error) {
-	variation, err := ec.getAssignment(ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, numericVariation)
+func (ec *EppoClient) GetNumericAssignment(
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue float64,
+) (float64, error) {
+	return ec.getNumericAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) GetNumericAssignmentContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue float64,
+) (float64, error) {
+	return ec.getNumericAssignment(ctx, flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) getNumericAssignment(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue float64,
+) (float64, error) {
+	variation, err := ec.getAssignment(ctx, ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, numericVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -73,8 +121,30 @@ func (ec *EppoClient) GetNumericAssignment(flagKey string, subjectKey string, su
 	return result, err
 }
 
-func (ec *EppoClient) GetIntegerAssignment(flagKey string, subjectKey string, subjectAttributes Attributes, defaultValue int64) (int64, error) {
-	variation, err := ec.getAssignment(ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, integerVariation)
+func (ec *EppoClient) GetIntegerAssignment(
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue int64,
+) (int64, error) {
+	return ec.getIntegerAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) GetIntegerAssignmentContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue int64,
+) (int64, error) {
+	return ec.getIntegerAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) getIntegerAssignment(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue int64,
+) (int64, error) {
+	variation, err := ec.getAssignment(ctx, ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, integerVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -86,8 +156,30 @@ func (ec *EppoClient) GetIntegerAssignment(flagKey string, subjectKey string, su
 	return result, err
 }
 
-func (ec *EppoClient) GetStringAssignment(flagKey string, subjectKey string, subjectAttributes Attributes, defaultValue string) (string, error) {
-	variation, err := ec.getAssignment(ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, stringVariation)
+func (ec *EppoClient) GetStringAssignment(
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue string,
+) (string, error) {
+	return ec.getStringAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) GetStringAssignmentContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue string,
+) (string, error) {
+	return ec.getStringAssignment(ctx, flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) getStringAssignment(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue string,
+) (string, error) {
+	variation, err := ec.getAssignment(ctx, ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, stringVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -99,8 +191,30 @@ func (ec *EppoClient) GetStringAssignment(flagKey string, subjectKey string, sub
 	return result, err
 }
 
-func (ec *EppoClient) GetJSONAssignment(flagKey string, subjectKey string, subjectAttributes Attributes, defaultValue interface{}) (interface{}, error) {
-	variation, err := ec.getAssignment(ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, jsonVariation)
+func (ec *EppoClient) GetJSONAssignment(
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue any,
+) (any, error) {
+	return ec.getJSONAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) GetJSONAssignmentContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue any,
+) (any, error) {
+	return ec.getJSONAssignment(ctx, flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) getJSONAssignment(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue any,
+) (any, error) {
+	variation, err := ec.getAssignment(ctx, ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, jsonVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -112,8 +226,30 @@ func (ec *EppoClient) GetJSONAssignment(flagKey string, subjectKey string, subje
 	return result.Parsed, err
 }
 
-func (ec *EppoClient) GetJSONBytesAssignment(flagKey string, subjectKey string, subjectAttributes Attributes, defaultValue []byte) ([]byte, error) {
-	variation, err := ec.getAssignment(ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, jsonVariation)
+func (ec *EppoClient) GetJSONBytesAssignment(
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue []byte,
+) ([]byte, error) {
+	return ec.getJSONBytesAssignment(context.Background(), flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) GetJSONBytesAssignmentContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue []byte,
+) ([]byte, error) {
+	return ec.getJSONBytesAssignment(ctx, flagKey, subjectKey, subjectAttributes, defaultValue)
+}
+
+func (ec *EppoClient) getJSONBytesAssignment(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes Attributes,
+	defaultValue []byte,
+) ([]byte, error) {
+	variation, err := ec.getAssignment(ctx, ec.configurationStore.getConfiguration(), flagKey, subjectKey, subjectAttributes, jsonVariation)
 	if err != nil || variation == nil {
 		return defaultValue, err
 	}
@@ -130,11 +266,36 @@ type BanditResult struct {
 	Action    *string
 }
 
-func (ec *EppoClient) GetBanditAction(flagKey string, subjectKey string, subjectAttributes ContextAttributes, actions map[string]ContextAttributes, defaultVariation string) BanditResult {
+func (ec *EppoClient) GetBanditAction(
+	flagKey, subjectKey string,
+	subjectAttributes ContextAttributes,
+	actions map[string]ContextAttributes,
+	defaultVariation string,
+) BanditResult {
+	return ec.getBanditAction(context.Background(), flagKey, subjectKey, subjectAttributes, actions, defaultVariation)
+}
+
+func (ec *EppoClient) GetBanditActionContext(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes ContextAttributes,
+	actions map[string]ContextAttributes,
+	defaultVariation string,
+) BanditResult {
+	return ec.getBanditAction(ctx, flagKey, subjectKey, subjectAttributes, actions, defaultVariation)
+}
+
+func (ec *EppoClient) getBanditAction(
+	ctx context.Context,
+	flagKey, subjectKey string,
+	subjectAttributes ContextAttributes,
+	actions map[string]ContextAttributes,
+	defaultVariation string,
+) BanditResult {
 	config := ec.configurationStore.getConfiguration()
 
 	// ignoring the error here as we can always proceed with default variation
-	assignmentValue, _ := ec.getAssignment(config, flagKey, subjectKey, subjectAttributes.toGenericAttributes(), stringVariation)
+	assignmentValue, _ := ec.getAssignment(ctx, config, flagKey, subjectKey, subjectAttributes.toGenericAttributes(), stringVariation)
 	variation, ok := assignmentValue.(string)
 	if !ok {
 		variation = defaultVariation
@@ -172,38 +333,24 @@ func (ec *EppoClient) GetBanditAction(flagKey string, subjectKey string, subject
 		actions:           actions,
 	})
 
-	if logger, ok := ec.logger.(BanditActionLogger); ok {
-		event := BanditEvent{
-			FlagKey:                      flagKey,
-			BanditKey:                    bandit.BanditKey,
-			Subject:                      subjectKey,
-			Action:                       evaluation.actionKey,
-			ActionProbability:            evaluation.actionWeight,
-			OptimalityGap:                evaluation.optimalityGap,
-			ModelVersion:                 bandit.ModelVersion,
-			Timestamp:                    time.Now().UTC().Format(time.RFC3339),
-			SubjectNumericAttributes:     evaluation.subjectAttributes.Numeric,
-			SubjectCategoricalAttributes: evaluation.subjectAttributes.Categorical,
-			ActionNumericAttributes:      evaluation.actionAttributes.Numeric,
-			ActionCategoricalAttributes:  evaluation.actionAttributes.Categorical,
-			MetaData: map[string]string{
-				"sdkLanguage": "go",
-				"sdkVersion":  __version__,
-			},
-		}
-
-		func() {
-			// need to catch panics from Logger and continue
-			defer func() {
-				r := recover()
-				if r != nil {
-					fmt.Println("panic occurred:", r)
-				}
-			}()
-
-			logger.LogBanditAction(event)
-		}()
-	}
+	ec.logBanditAction(ctx, BanditEvent{
+		FlagKey:                      flagKey,
+		BanditKey:                    bandit.BanditKey,
+		Subject:                      subjectKey,
+		Action:                       evaluation.actionKey,
+		ActionProbability:            evaluation.actionWeight,
+		OptimalityGap:                evaluation.optimalityGap,
+		ModelVersion:                 bandit.ModelVersion,
+		Timestamp:                    time.Now().UTC().Format(time.RFC3339),
+		SubjectNumericAttributes:     evaluation.subjectAttributes.Numeric,
+		SubjectCategoricalAttributes: evaluation.subjectAttributes.Categorical,
+		ActionNumericAttributes:      evaluation.actionAttributes.Numeric,
+		ActionCategoricalAttributes:  evaluation.actionAttributes.Categorical,
+		MetaData: map[string]string{
+			"sdkLanguage": "go",
+			"sdkVersion":  __version__,
+		},
+	})
 
 	return BanditResult{
 		Variation: variation,
@@ -211,7 +358,7 @@ func (ec *EppoClient) GetBanditAction(flagKey string, subjectKey string, subject
 	}
 }
 
-func (ec *EppoClient) getAssignment(config configuration, flagKey string, subjectKey string, subjectAttributes Attributes, variationType variationType) (interface{}, error) {
+func (ec *EppoClient) getAssignment(ctx context.Context, config configuration, flagKey string, subjectKey string, subjectAttributes Attributes, variationType variationType) (interface{}, error) {
 	if subjectKey == "" {
 		return nil, fmt.Errorf("no subject key provided")
 	}
@@ -238,20 +385,53 @@ func (ec *EppoClient) getAssignment(config configuration, flagKey string, subjec
 		return nil, err
 	}
 
-	if assignmentEvent != nil {
-		func() {
-			// need to catch panics from Logger and continue
-			defer func() {
-				r := recover()
-				if r != nil {
-					ec.applicationLogger.Errorf("panic occurred: %v", r)
-				}
-			}()
+	ec.logAssignment(ctx, assignmentEvent)
+	return assignmentValue, nil
+}
 
-			// Log assignment
-			ec.logger.LogAssignment(*assignmentEvent)
-		}()
+func (ec *EppoClient) logAssignment(ctx context.Context, event *AssignmentEvent) {
+	if event == nil {
+		return
 	}
 
-	return assignmentValue, nil
+	// need to catch panics from Logger and continue
+	defer func() {
+		r := recover()
+		if r != nil {
+			ec.applicationLogger.Errorf("panic occurred: %v", r)
+		}
+	}()
+
+	switch {
+	case ec.loggerContext != nil:
+		// prioritise logger context if it's defined in the config
+		ec.loggerContext.LogAssignment(ctx, *event)
+	case ec.logger != nil:
+		ec.logger.LogAssignment(*event)
+	default:
+		// no need to do anything if both logger are nil
+	}
+}
+
+func (ec *EppoClient) logBanditAction(ctx context.Context, event BanditEvent) {
+	// need to catch panics from Logger and continue
+	defer func() {
+		r := recover()
+		if r != nil {
+			fmt.Println("panic occurred:", r)
+		}
+	}()
+
+	switch {
+	case ec.loggerContext != nil:
+		if l, ok := ec.loggerContext.(interface {
+			LogBanditAction(context.Context, BanditEvent)
+		}); ok {
+			l.LogBanditAction(ctx, event)
+		}
+	case ec.logger != nil:
+		if l, ok := ec.logger.(BanditActionLogger); ok {
+			l.LogBanditAction(event)
+		}
+	}
 }

--- a/eppoclient/config.go
+++ b/eppoclient/config.go
@@ -12,12 +12,13 @@ const defaultBaseUrl = "https://fscdn.eppo.cloud/api"
 const defaultPollerInterval = 10 * time.Second
 
 type Config struct {
-	BaseUrl           string
-	SdkKey            string
-	AssignmentLogger  IAssignmentLogger
-	PollerInterval    time.Duration
-	ApplicationLogger ApplicationLogger
-	HttpClient        *http.Client
+	BaseUrl                 string
+	SdkKey                  string
+	AssignmentLogger        IAssignmentLogger
+	AssignmentLoggerContext IAssignmentLoggerContext
+	PollerInterval          time.Duration
+	ApplicationLogger       ApplicationLogger
+	HttpClient              *http.Client
 }
 
 func (cfg *Config) validate() error {

--- a/eppoclient/initclient.go
+++ b/eppoclient/initclient.go
@@ -24,10 +24,15 @@ func InitClient(config Config) (*EppoClient, error) {
 	configStore := newConfigurationStore()
 	requestor := newConfigurationRequestor(*httpClient, configStore, applicationLogger)
 
-	assignmentLogger := config.AssignmentLogger
-
 	poller := newPoller(config.PollerInterval, requestor.FetchAndStoreConfigurations, applicationLogger)
-	client := newEppoClient(configStore, requestor, poller, assignmentLogger, applicationLogger)
+	client := newEppoClient(
+		configStore,
+		requestor,
+		poller,
+		config.AssignmentLogger,
+		config.AssignmentLoggerContext,
+		applicationLogger,
+	)
 
 	client.poller.Start()
 

--- a/eppoclient/mocks_test.go
+++ b/eppoclient/mocks_test.go
@@ -1,6 +1,8 @@
 package eppoclient
 
 import (
+	"context"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,6 +16,18 @@ func (ml *mockLogger) LogAssignment(event AssignmentEvent) {
 
 func (ml *mockLogger) LogBanditAction(event BanditEvent) {
 	ml.MethodCalled("LogBanditAction", event)
+}
+
+type mockLoggerContext struct {
+	mock.Mock
+}
+
+func (ml *mockLoggerContext) LogAssignment(ctx context.Context, event AssignmentEvent) {
+	ml.MethodCalled("LogAssignment", ctx, event)
+}
+
+func (ml *mockLoggerContext) LogBanditAction(ctx context.Context, event BanditEvent) {
+	ml.MethodCalled("LogBanditAction", ctx, event)
 }
 
 // `mockNonBanditLogger` is missing `LogBanditAction` and therefore


### PR DESCRIPTION
_Eppo Internal:_

[//]: #  (Link to the issue corresponding to this chunk of work)
:tickets: Fixes __issue__
:scroll: Design Doc: __link if applicable__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Add methods that pass context while getting assignment

## Description
[//]: # (Describe your changes in detail)

Context is very useful to pass values (e.g. for tracing in the logger)

## How has this been documented?
[//]: # (Please describe how you documented the developer impact of your changes; link to PRs or issues or explain why no documentation changes are required)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
